### PR TITLE
fix: sửa tiếng Việt có dấu và plain-text link trong deck giao tiếp [RD-994]

### DIFF
--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/01-title.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/01-title.tsx
@@ -70,7 +70,7 @@ export function Slide01Title() {
             marginBottom: 28,
           }}
         >
-          Developer Skills Series - Tieng Viet
+          Developer Skills Series - Tiếng Việt
         </motion.div>
 
         <motion.h1
@@ -83,8 +83,8 @@ export function Slide01Title() {
             marginBottom: 32,
           }}
         >
-          Giao tiep{' '}
-          <span style={{ color: theme.colors.accent }}>hieu qua</span>
+          Giao tiếp{' '}
+          <span style={{ color: theme.colors.accent }}>hiệu quả</span>
           <br />
           trong team
         </motion.h1>
@@ -108,7 +108,7 @@ export function Slide01Title() {
             maxWidth: 420,
           }}
         >
-          Huong dan thuc te danh cho fresher va junior developer buoc vao moi truong lam viec tech dau tien.
+          Hướng dẫn thực tế dành cho fresher và junior developer bước vào môi trường làm việc tech đầu tiên.
         </motion.p>
       </motion.div>
 
@@ -150,7 +150,7 @@ export function Slide01Title() {
             paddingLeft: 48,
           }}
         >
-          {['Lang nghe chu dong', 'Viet message ro rang', 'Daily standup', 'Bao cao & escalation', 'Code review', 'Feedback xay dung'].map((topic, i) => (
+          {['Lắng nghe chủ động', 'Viết message rõ ràng', 'Daily standup', 'Báo cáo & escalation', 'Code review', 'Feedback xây dựng'].map((topic, i) => (
             <motion.div
               key={topic}
               initial={{ opacity: 0, x: 20 }}

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/02-tai-sao.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/02-tai-sao.tsx
@@ -3,9 +3,9 @@ import { theme } from '../lib/theme'
 import { container, fadeInUp, containerFast } from '../lib/animations'
 
 const stats = [
-  { value: '86%', label: 'that bai cua cac du an la do giao tiep kem' },
-  { value: '4x', label: 'hieu suat khi team giao tiep tot hon' },
-  { value: '#1', label: 'ky nang nha tuyen dung tim kiem o junior dev' },
+  { value: '86%', label: 'thất bại của các dự án là do giao tiếp kém' },
+  { value: '4x', label: 'hiệu suất khi team giao tiếp tốt hơn' },
+  { value: '#1', label: 'kỹ năng nhà tuyển dụng tìm kiếm ở junior dev' },
 ]
 
 export function Slide02TaiSao() {
@@ -63,7 +63,7 @@ export function Slide02TaiSao() {
             marginBottom: 12,
           }}
         >
-          Tai sao giao tiep <span style={{ color: theme.colors.accent }}>quan trong?</span>
+          Tại sao giao tiếp <span style={{ color: theme.colors.accent }}>quan trọng?</span>
         </motion.h2>
 
         <motion.p
@@ -76,7 +76,7 @@ export function Slide02TaiSao() {
             lineHeight: 1.6,
           }}
         >
-          Ky nang ky thuat chi la mot phan - giao tiep la thu tao ra su khac biet giua nguoi binh thuong va nguoi xuat sac.
+          Kỹ năng kỹ thuật chỉ là một phần - giao tiếp là thứ tạo ra sự khác biệt giữa người bình thường và người xuất sắc.
         </motion.p>
 
         <motion.div
@@ -137,7 +137,7 @@ export function Slide02TaiSao() {
             maxWidth: 700,
           }}
         >
-          <strong style={{ color: theme.colors.accent }}>Key insight:</strong> Code tot nhung giao tiep kem = blocker cho ca team. Code trung binh nhung giao tiep tot = contributor gia tri.
+          <strong style={{ color: theme.colors.accent }}>Key insight:</strong> Code tốt nhưng giao tiếp kém = blocker cho cả team. Code trung bình nhưng giao tiếp tốt = contributor giá trị.
         </motion.div>
       </motion.div>
     </div>

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/03-hinh-thuc.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/03-hinh-thuc.tsx
@@ -3,10 +3,10 @@ import { theme } from '../lib/theme'
 import { container, fadeInUp, containerFast } from '../lib/animations'
 
 const forms = [
-  { icon: '💬', title: 'Dong bo (Sync)', desc: 'Meeting, call, standup, pair programming - moi nguoi online cung luc' },
-  { icon: '📝', title: 'Bat dong bo (Async)', desc: 'Email, Slack, comment, doc - moi nguoi tra loi khi ranh' },
-  { icon: '🖥️', title: 'Bang van ban', desc: 'PR description, ticket, wiki, README - luu lai de tham khao' },
-  { icon: '🎤', title: 'Bang loi noi', desc: 'Trao doi truc tiep, review, 1:1 - nhanh nhung khong luu vet' },
+  { icon: '💬', title: 'Đồng bộ (Sync)', desc: 'Meeting, call, standup, pair programming - mọi người online cùng lúc' },
+  { icon: '📝', title: 'Bất đồng bộ (Async)', desc: 'Email, Slack, comment, doc - mọi người trả lời khi rảnh' },
+  { icon: '🖥️', title: 'Bằng văn bản', desc: 'PR description, ticket, wiki, README - lưu lại để tham khảo' },
+  { icon: '🎤', title: 'Bằng lời nói', desc: 'Trao đổi trực tiếp, review, 1:1 - nhanh nhưng không lưu vết' },
 ]
 
 export function Slide03HinhThuc() {
@@ -64,7 +64,7 @@ export function Slide03HinhThuc() {
             marginBottom: 40,
           }}
         >
-          Cac hinh thuc <span style={{ color: theme.colors.accent }}>giao tiep trong team</span>
+          Các hình thức <span style={{ color: theme.colors.accent }}>giao tiếp trong team</span>
         </motion.h2>
 
         <motion.div

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/04-lang-nghe.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/04-lang-nghe.tsx
@@ -3,11 +3,11 @@ import { theme } from '../lib/theme'
 import { container, fadeInUp, containerFast } from '../lib/animations'
 
 const tips = [
-  { num: '01', text: 'Khong ngat loi nguoi khac dang noi - de ho noi xong hoan toan' },
-  { num: '02', text: 'Xac nhan lai bang cach tom tat: "Y ban la..."' },
-  { num: '03', text: 'Dat cau hoi lam ro, khong dua ra ket luan qua som' },
-  { num: '04', text: 'De y ngon ngu co the (expression, tone) khi noi chuyen truc tiep' },
-  { num: '05', text: 'Ghi chu nhung diem quan trong de khong quen' },
+  { num: '01', text: 'Không ngắt lời người khác đang nói - để họ nói xong hoàn toàn' },
+  { num: '02', text: 'Xác nhận lại bằng cách tóm tắt: "Ý bạn là..."' },
+  { num: '03', text: 'Đặt câu hỏi làm rõ, không đưa ra kết luận quá sớm' },
+  { num: '04', text: 'Để ý ngôn ngữ cơ thể (expression, tone) khi nói chuyện trực tiếp' },
+  { num: '05', text: 'Ghi chú những điểm quan trọng để không quên' },
 ]
 
 export function Slide04LangNghe() {
@@ -72,8 +72,8 @@ export function Slide04LangNghe() {
             lineHeight: 1.15,
           }}
         >
-          Lang nghe{' '}
-          <span style={{ color: theme.colors.accent }}>chu dong</span>
+          Lắng nghe{' '}
+          <span style={{ color: theme.colors.accent }}>chủ động</span>
         </motion.h2>
 
         <motion.p
@@ -86,7 +86,7 @@ export function Slide04LangNghe() {
             maxWidth: 380,
           }}
         >
-          Active listening khong phai nghe de cho den luot minh noi. Do la ky nang nghe de hieu - hieu nguoi, hieu van de, hieu boi canh.
+          Active listening không phải nghe để chờ đến lượt mình nói. Đó là kỹ năng nghe để hiểu - hiểu người, hiểu vấn đề, hiểu bối cảnh.
         </motion.p>
 
         <motion.div
@@ -101,7 +101,7 @@ export function Slide04LangNghe() {
             maxWidth: 380,
           }}
         >
-          <strong>Nho:</strong> Junior hay mac loi noi nhieu hon nghe. Dao nguoc lai se tao su khac biet lon.
+          <strong>Nhớ:</strong> Junior hay mắc lỗi nói nhiều hơn nghe. Đảo ngược lại sẽ tạo sự khác biệt lớn.
         </motion.div>
       </motion.div>
 

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/05-dat-cau-hoi.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/05-dat-cau-hoi.tsx
@@ -3,15 +3,15 @@ import { theme } from '../lib/theme'
 import { container, fadeInUp, containerFast } from '../lib/animations'
 
 const good = [
-  '"Minh hieu requirement nay la X - ban xac nhan duoc khong?"',
-  '"Minh dang bi ket o buoc Y, ban co the cho minh biet cach tiep can khong?"',
-  '"Deadline nay co flexible khong neu gap van de phat sinh?"',
+  '"Mình hiểu requirement này là X - bạn xác nhận được không?"',
+  '"Mình đang bị kẹt ở bước Y, bạn có thể cho mình biết cách tiếp cận không?"',
+  '"Deadline này có flexible không nếu gặp vấn đề phát sinh?"',
 ]
 
 const bad = [
-  '"Lam the nao?" (qua mo, khong co context)',
-  '"No bi loi roi" (khong mo ta ro loi gi, o dau)',
-  '"OK" (khong xac nhan minh hieu dung hay chua)',
+  '"Làm thế nào?" (quá mơ, không có context)',
+  '"Nó bị lỗi rồi" (không mô tả rõ lỗi gì, ở đâu)',
+  '"OK" (không xác nhận mình hiểu đúng hay chưa)',
 ]
 
 export function Slide05DatCauHoi() {
@@ -69,7 +69,7 @@ export function Slide05DatCauHoi() {
             marginBottom: 32,
           }}
         >
-          Ky nang <span style={{ color: theme.colors.accent }}>dat cau hoi dung</span>
+          Kỹ năng <span style={{ color: theme.colors.accent }}>đặt câu hỏi đúng</span>
         </motion.h2>
 
         <motion.div
@@ -88,7 +88,7 @@ export function Slide05DatCauHoi() {
                 gap: 8,
               }}
             >
-              <span>+</span> Cau hoi tot
+              <span>+</span> Câu hỏi tốt
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
               {good.map((q, i) => (
@@ -123,7 +123,7 @@ export function Slide05DatCauHoi() {
                 gap: 8,
               }}
             >
-              <span>-</span> Cau hoi nen tranh
+              <span>-</span> Câu hỏi nên tránh
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
               {bad.map((q, i) => (
@@ -159,7 +159,7 @@ export function Slide05DatCauHoi() {
             color: theme.colors.text,
           }}
         >
-          <strong style={{ color: theme.colors.accent }}>Cong thuc dat cau hoi tot:</strong> Boi canh + Dieu minh da thu + Ket qua mong muon = Cau hoi ro rang, de tra loi
+          <strong style={{ color: theme.colors.accent }}>Công thức đặt câu hỏi tốt:</strong> Bối cảnh + Điều mình đã thử + Kết quả mong muốn = Câu hỏi rõ ràng, dễ trả lời
         </motion.div>
       </motion.div>
     </div>

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/06-van-ban.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/06-van-ban.tsx
@@ -3,11 +3,11 @@ import { theme } from '../lib/theme'
 import { container, fadeInUp, containerFast } from '../lib/animations'
 
 const channels = [
-  { icon: '📧', name: 'Email', when: 'Thong bao chinh thuc, lien he ngoai cong ty, cac van de can luu vet' },
-  { icon: '💬', name: 'Slack / Chat', when: 'Trao doi nhanh, hoi dap, cap nhat trang thai trong ngay' },
-  { icon: '📋', name: 'Jira / Ticket', when: 'Mo ta task, bug report, cap nhat tien do cong viec' },
-  { icon: '🔍', name: 'PR Comment', when: 'Review code, giai thich implementation, yeu cau thay doi' },
-  { icon: '📄', name: 'Confluence / Doc', when: 'Tai lieu kien truc, decision log, huong dan su dung' },
+  { icon: '📧', name: 'Email', when: 'Thông báo chính thức, liên hệ ngoài công ty, các vấn đề cần lưu vết' },
+  { icon: '💬', name: 'Slack / Chat', when: 'Trao đổi nhanh, hỏi đáp, cập nhật trạng thái trong ngày' },
+  { icon: '📋', name: 'Jira / Ticket', when: 'Mô tả task, bug report, cập nhật tiến độ công việc' },
+  { icon: '🔍', name: 'PR Comment', when: 'Review code, giải thích implementation, yêu cầu thay đổi' },
+  { icon: '📄', name: 'Confluence / Doc', when: 'Tài liệu kiến trúc, decision log, hướng dẫn sử dụng' },
 ]
 
 export function Slide06VanBan() {
@@ -65,7 +65,7 @@ export function Slide06VanBan() {
             marginBottom: 8,
           }}
         >
-          Giao tiep bang <span style={{ color: theme.colors.accent }}>van ban</span>
+          Giao tiếp bằng <span style={{ color: theme.colors.accent }}>văn bản</span>
         </motion.h2>
 
         <motion.p
@@ -76,7 +76,7 @@ export function Slide06VanBan() {
             marginBottom: 32,
           }}
         >
-          Dung dung kenh - gui dung cho - la ky nang co ban nhieu junior con thieu.
+          Dùng đúng kênh - gửi đúng chỗ - là kỹ năng cơ bản nhiều junior còn thiếu.
         </motion.p>
 
         <motion.div

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/07-viet-message.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/07-viet-message.tsx
@@ -64,15 +64,15 @@ export function Slide07VietMessage() {
             lineHeight: 1.2,
           }}
         >
-          Viet message <span style={{ color: theme.colors.accent }}>ro rang, ngan gon</span>
+          Viết message <span style={{ color: theme.colors.accent }}>rõ ràng, ngắn gọn</span>
         </motion.h2>
 
         <motion.div variants={fadeInUp} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
           {[
-            { label: 'BLUF', desc: 'Bottom Line Up Front - ket luan truoc, chi tiet sau' },
-            { label: 'Context', desc: 'Neu boi canh de nguoi doc hieu van de' },
-            { label: 'Action', desc: 'Neu ro ban can gi: review, approve, phan hoi' },
-            { label: 'Deadline', desc: 'Neu co urgent, ghi ro thoi han cu the' },
+            { label: 'BLUF', desc: 'Bottom Line Up Front - kết luận trước, chi tiết sau' },
+            { label: 'Context', desc: 'Nêu bối cảnh để người đọc hiểu vấn đề' },
+            { label: 'Action', desc: 'Nêu rõ bạn cần gì: review, approve, phản hồi' },
+            { label: 'Deadline', desc: 'Nếu có urgent, ghi rõ thời hạn cụ thể' },
           ].map((item) => (
             <motion.div
               key={item.label}
@@ -151,25 +151,20 @@ export function Slide07VietMessage() {
               marginBottom: 14,
             }}
           >
-            Vi du message tot:
+            Ví dụ message tốt:
           </div>
           <div
             style={{
               fontSize: theme.sizes.small,
               color: theme.colors.text,
               lineHeight: 1.8,
-              fontFamily: 'monospace',
-              background: '#f8f9fa',
-              padding: '16px',
-              borderRadius: 8,
-              border: `1px solid ${theme.colors.border}`,
             }}
           >
-            <div style={{ color: theme.colors.accent, fontWeight: 700 }}>@Nam - Can review PR #142 truoc 5pm hom nay</div>
+            <div style={{ color: theme.colors.accent, fontWeight: 700 }}>@Nam - Cần review PR #142 trước 5pm hôm nay</div>
             <br />
-            <div>Boi canh: Feature login se bi block neu PR nay chua duoc merge.</div>
+            <div>Bối cảnh: Feature login sẽ bị block nếu PR này chưa được merge.</div>
             <br />
-            <div>Da test o local, pass all unit tests. Can them 1 pair of eyes cho phan error handling (line 45-60).</div>
+            <div>Đã test ở local, pass all unit tests. Cần thêm 1 pair of eyes cho phần error handling (line 45-60).</div>
             <br />
             <div>Link: github.com/org/repo/pull/142</div>
           </div>

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/08-daily-standup.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/08-daily-standup.tsx
@@ -4,19 +4,19 @@ import { container, fadeInUp, containerFast } from '../lib/animations'
 
 const questions = [
   {
-    q: 'Hom qua lam gi?',
-    hint: 'Task cu the, khong chi noi "lam feature X"',
-    example: '"Hoan thanh API endpoint /users/login, da viet unit test"',
+    q: 'Hôm qua làm gì?',
+    hint: 'Task cụ thể, không chỉ nói "làm feature X"',
+    example: '"Hoàn thành API endpoint /users/login, đã viết unit test"',
   },
   {
-    q: 'Hom nay se lam gi?',
-    hint: 'Plan ro rang, estimate neu co the',
-    example: '"Se implement phan validate token, du kien xong truoc 3pm"',
+    q: 'Hôm nay sẽ làm gì?',
+    hint: 'Plan rõ ràng, estimate nếu có thể',
+    example: '"Sẽ implement phần validate token, dự kiến xong trước 3pm"',
   },
   {
-    q: 'Co gi can ho tro khong?',
-    hint: 'Nen noi ro blocker ngay - dung giu trong long',
-    example: '"Dang bi ket o viec cau hinh Redis, can ai co kinh nghiem ho tro"',
+    q: 'Có gì cần hỗ trợ không?',
+    hint: 'Nên nói rõ blocker ngay - đừng giữ trong lòng',
+    example: '"Đang bị kẹt ở việc cấu hình Redis, cần ai có kinh nghiệm hỗ trợ"',
   },
 ]
 
@@ -75,7 +75,7 @@ export function Slide08DailyStandup() {
             marginBottom: 8,
           }}
         >
-          Giao tiep trong <span style={{ color: theme.colors.accent }}>daily standup</span>
+          Giao tiếp trong <span style={{ color: theme.colors.accent }}>daily standup</span>
         </motion.h2>
 
         <motion.p
@@ -86,7 +86,7 @@ export function Slide08DailyStandup() {
             marginBottom: 28,
           }}
         >
-          15 phut moi ngay - giu ngan gon, tap trung, khong dung thuyet trinh dai dong.
+          15 phút mỗi ngày - giữ ngắn gọn, tập trung, không dùng thuyết trình dài dòng.
         </motion.p>
 
         <motion.div

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/09-bao-cao.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/09-bao-cao.tsx
@@ -8,21 +8,21 @@ const levels = [
     color: theme.colors.positive,
     bg: 'rgba(5,150,105,0.08)',
     border: 'rgba(5,150,105,0.25)',
-    desc: 'Dung track, khong co van de. Cap nhat ngan trong standup la du.',
+    desc: 'Đúng track, không có vấn đề. Cập nhật ngắn trong standup là đủ.',
   },
   {
-    signal: 'Vang',
+    signal: 'Vàng',
     color: '#d97706',
     bg: 'rgba(217,119,6,0.08)',
     border: 'rgba(217,119,6,0.25)',
-    desc: 'Co rui ro, co the tre han. Bao ngay cho lead / PM, de xuat giai phap.',
+    desc: 'Có rủi ro, có thể trễ hạn. Báo ngay cho lead / PM, đề xuất giải pháp.',
   },
   {
-    signal: 'Do',
+    signal: 'Đỏ',
     color: theme.colors.negative,
     bg: 'rgba(220,38,38,0.07)',
     border: 'rgba(220,38,38,0.2)',
-    desc: 'Da bi block, khong the tu giai quyet. Escalate ngay, khong cho them.',
+    desc: 'Đã bị block, không thể tự giải quyết. Escalate ngay, không chờ thêm.',
   },
 ]
 
@@ -81,7 +81,7 @@ export function Slide09BaoCao() {
             marginBottom: 8,
           }}
         >
-          Bao cao tien do & <span style={{ color: theme.colors.accent }}>escalation dung luc</span>
+          Báo cáo tiến độ & <span style={{ color: theme.colors.accent }}>escalation đúng lúc</span>
         </motion.h2>
 
         <motion.p
@@ -93,7 +93,7 @@ export function Slide09BaoCao() {
             maxWidth: 700,
           }}
         >
-          Quy tac vang: <strong>khong co tin xau nao la tin xau neu duoc bao som.</strong> Im lang moi la van de.
+          Quy tắc vàng: <strong>không có tin xấu nào là tin xấu nếu được báo sớm.</strong> Im lặng mới là vấn đề.
         </motion.p>
 
         <motion.div
@@ -151,7 +151,7 @@ export function Slide09BaoCao() {
             color: theme.colors.text,
           }}
         >
-          <strong style={{ color: theme.colors.accent }}>Loi junior hay gap:</strong> Giu blocker trong long vi so bi danh gia "cham". Thuc te: escalate som = phan chieu tich cuc.
+          <strong style={{ color: theme.colors.accent }}>Lỗi junior hay gặp:</strong> Giữ blocker trong lòng vì sợ bị đánh giá "chậm". Thực tế: escalate sớm = phản chiếu tích cực.
         </motion.div>
       </motion.div>
     </div>

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/10-blocker.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/10-blocker.tsx
@@ -3,10 +3,10 @@ import { theme } from '../lib/theme'
 import { container, fadeInUp } from '../lib/animations'
 
 const template = [
-  { label: 'Dang lam gi', example: '"Minh dang implement feature X theo ticket ABC-123"' },
-  { label: 'Van de gap phai', example: '"Bi loi 403 Forbidden khi goi API /auth/token, du da gui dung token"' },
-  { label: 'Da thu gi roi', example: '"Da check docs, thu regenerate token, va debug voi Postman - van bi loi"' },
-  { label: 'Can ho tro gi', example: '"Can ai co access vao server log de kiem tra phia backend co thay loi gi khong"' },
+  { label: 'Đang làm gì', example: '"Mình đang implement feature X theo ticket ABC-123"' },
+  { label: 'Vấn đề gặp phải', example: '"Bị lỗi 403 Forbidden khi gọi API /auth/token, dù đã gửi đúng token"' },
+  { label: 'Đã thử gì rồi', example: '"Đã check docs, thử regenerate token, và debug với Postman - vẫn bị lỗi"' },
+  { label: 'Cần hỗ trợ gì', example: '"Cần ai có access vào server log để kiểm tra phía backend có thấy lỗi gì không"' },
 ]
 
 export function Slide10Blocker() {
@@ -64,7 +64,7 @@ export function Slide10Blocker() {
             marginBottom: 8,
           }}
         >
-          Giao tiep khi gap <span style={{ color: theme.colors.accent }}>blocker</span>
+          Giao tiếp khi gặp <span style={{ color: theme.colors.accent }}>blocker</span>
         </motion.h2>
 
         <motion.p
@@ -75,7 +75,7 @@ export function Slide10Blocker() {
             marginBottom: 28,
           }}
         >
-          Template bao blocker hieu qua - dung bao loai "em bi loi roi anh oi" roi cho:
+          Template báo blocker hiệu quả - đừng báo loại "em bị lỗi rồi anh ơi" rồi chờ:
         </motion.p>
 
         <motion.div
@@ -138,7 +138,7 @@ export function Slide10Blocker() {
             color: theme.colors.text,
           }}
         >
-          <strong style={{ color: theme.colors.accent }}>Quy tac 15 phut:</strong> Tu debug toi da 15-30 phut. Neu van bi ket, bao ngay - dung de mat ca ngay vi mot van de co the duoc giai quyet trong 5 phut.
+          <strong style={{ color: theme.colors.accent }}>Quy tắc 15 phút:</strong> Tự debug tối đa 15-30 phút. Nếu vẫn bị kẹt, báo ngay - đừng để mất cả ngày vì một vấn đề có thể được giải quyết trong 5 phút.
         </motion.div>
       </motion.div>
     </div>

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/11-feedback.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/11-feedback.tsx
@@ -3,17 +3,17 @@ import { theme } from '../lib/theme'
 import { container, fadeInUp, containerFast } from '../lib/animations'
 
 const giving = [
-  'Noi ve hanh dong, khong noi ve con nguoi',
-  'Cu the, co vi du thuc te - tranh chung chung',
-  'De xuat giai phap thay vi chi chi trich',
-  'Chon thoi diem phu hop, khong feedback truoc mat nhieu nguoi',
+  'Nói về hành động, không nói về con người',
+  'Cụ thể, có ví dụ thực tế - tránh chung chung',
+  'Đề xuất giải pháp thay vì chỉ chỉ trích',
+  'Chọn thời điểm phù hợp, không feedback trước mặt nhiều người',
 ]
 
 const receiving = [
-  'Lang nghe den cung, khong bien minh de cam on',
-  'Khong "defend" ngay - hieu truoc, phan hoi sau',
-  'Dat cau hoi lam ro neu feedback khong cu the',
-  'Cam on - du ban co dong y hay khong',
+  'Lắng nghe đến cùng, không biện minh - để cảm ơn',
+  'Không "defend" ngay - hiểu trước, phản hồi sau',
+  'Đặt câu hỏi làm rõ nếu feedback không cụ thể',
+  'Cảm ơn - dù bạn có đồng ý hay không',
 ]
 
 export function Slide11Feedback() {
@@ -71,7 +71,7 @@ export function Slide11Feedback() {
             marginBottom: 32,
           }}
         >
-          Nhan va dua <span style={{ color: theme.colors.accent }}>feedback xay dung</span>
+          Nhận và đưa <span style={{ color: theme.colors.accent }}>feedback xây dựng</span>
         </motion.h2>
 
         <motion.div
@@ -90,7 +90,7 @@ export function Slide11Feedback() {
                 gap: 8,
               }}
             >
-              Khi dua feedback
+              Khi đưa feedback
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
               {giving.map((tip, i) => (
@@ -137,7 +137,7 @@ export function Slide11Feedback() {
                 gap: 8,
               }}
             >
-              Khi nhan feedback
+              Khi nhận feedback
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
               {receiving.map((tip, i) => (

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/12-hieu-lam.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/12-hieu-lam.tsx
@@ -5,19 +5,19 @@ import { container, fadeInUp, containerFast } from '../lib/animations'
 const scenarios = [
   {
     situation: 'Sau meeting',
-    action: 'Gui summary qua email/Slack: "De minh xac nhan lai: cac diem da thong nhat la..."',
+    action: 'Gửi summary qua email/Slack: "Để mình xác nhận lại: các điểm đã thống nhất là..."',
   },
   {
-    situation: 'Nhan task moi',
-    action: 'Lap lai yeu cau bang loi cua minh truoc khi bat dau lam de kiem tra hieu dung chua',
+    situation: 'Nhận task mới',
+    action: 'Lặp lại yêu cầu bằng lời của mình trước khi bắt đầu làm để kiểm tra hiểu đúng chưa',
   },
   {
-    situation: 'Giao tiep bat dong bo',
-    action: 'Neu khong chac, hoi them: "Minh hieu la X - ban xac nhan duoc khong?"',
+    situation: 'Giao tiếp bất đồng bộ',
+    action: 'Nếu không chắc, hỏi thêm: "Mình hiểu là X - bạn xác nhận được không?"',
   },
   {
-    situation: 'Khi biet re quan diem',
-    action: 'Chuyen sang sync ngay: "Hay co 5 phut call de hieu ro hon" thay vi chat qua lai mai',
+    situation: 'Khi biết rẽ quan điểm',
+    action: 'Chuyển sang sync ngay: "Hãy có 5 phút call để hiểu rõ hơn" thay vì chat qua lại mãi',
   },
 ]
 
@@ -76,7 +76,7 @@ export function Slide12HieuLam() {
             marginBottom: 8,
           }}
         >
-          Tranh hieu lam - <span style={{ color: theme.colors.accent }}>xac nhan lai thong tin</span>
+          Tránh hiểu lầm - <span style={{ color: theme.colors.accent }}>xác nhận lại thông tin</span>
         </motion.h2>
 
         <motion.p
@@ -87,7 +87,7 @@ export function Slide12HieuLam() {
             marginBottom: 28,
           }}
         >
-          Hieu lam xay ra thuong xuyen - van de khong phai la hieu lam ma la khong kiem tra lai de phat hien som.
+          Hiểu lầm xảy ra thường xuyên - vấn đề không phải là hiểu lầm mà là không kiểm tra lại để phát hiện sớm.
         </motion.p>
 
         <motion.div

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/13-sync-async.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/13-sync-async.tsx
@@ -3,17 +3,17 @@ import { theme } from '../lib/theme'
 import { container, fadeInUp, containerFast } from '../lib/animations'
 
 const syncItems = [
-  { text: 'Van de phuc tap, can trao doi nhieu chieu' },
-  { text: 'Emergency, can giai quyet ngay' },
+  { text: 'Vấn đề phức tạp, cần trao đổi nhiều chiều' },
+  { text: 'Emergency, cần giải quyết ngay' },
   { text: 'Onboarding, brainstorm, retro' },
-  { text: 'Boi canh nay sinh hieu lam lien tuc' },
+  { text: 'Bối cảnh nảy sinh hiểu lầm liên tục' },
 ]
 
 const asyncItems = [
-  { text: 'Cap nhat trang thai, khong can phan hoi ngay' },
-  { text: 'Yeu cau review, phan hoi, ho tro' },
-  { text: 'Tai lieu, wiki, decision log' },
-  { text: 'Thong bao den nhieu nguoi cung luc' },
+  { text: 'Cập nhật trạng thái, không cần phản hồi ngay' },
+  { text: 'Yêu cầu review, phản hồi, hỗ trợ' },
+  { text: 'Tài liệu, wiki, decision log' },
+  { text: 'Thông báo đến nhiều người cùng lúc' },
 ]
 
 export function Slide13SyncAsync() {
@@ -71,7 +71,7 @@ export function Slide13SyncAsync() {
             marginBottom: 32,
           }}
         >
-          Giao tiep <span style={{ color: theme.colors.accent }}>dong bo vs. bat dong bo</span>
+          Giao tiếp <span style={{ color: theme.colors.accent }}>đồng bộ vs. bất đồng bộ</span>
         </motion.h2>
 
         <motion.div
@@ -89,10 +89,10 @@ export function Slide13SyncAsync() {
               }}
             >
               <div style={{ fontSize: theme.sizes.body, fontWeight: 700, color: theme.colors.accent, marginBottom: 4 }}>
-                Dong bo (Meeting / Call)
+                Đồng bộ (Meeting / Call)
               </div>
               <div style={{ fontSize: theme.sizes.small, color: theme.colors.textMuted }}>
-                Nen dung khi...
+                Nên dùng khi...
               </div>
             </div>
             {syncItems.map((item, i) => (
@@ -137,10 +137,10 @@ export function Slide13SyncAsync() {
               }}
             >
               <div style={{ fontSize: theme.sizes.body, fontWeight: 700, color: theme.colors.positive, marginBottom: 4 }}>
-                Bat dong bo (Chat / Doc)
+                Bất đồng bộ (Chat / Doc)
               </div>
               <div style={{ fontSize: theme.sizes.small, color: theme.colors.textMuted }}>
-                Nen dung khi...
+                Nên dùng khi...
               </div>
             </div>
             {asyncItems.map((item, i) => (
@@ -187,7 +187,7 @@ export function Slide13SyncAsync() {
             color: theme.colors.text,
           }}
         >
-          <strong style={{ color: theme.colors.accent }}>Default async, sync khi can thiet.</strong> Khong nen to chuc meeting de bao ket qua co the gui Slack - ton thoi gian ca team.
+          <strong style={{ color: theme.colors.accent }}>Default async, sync khi cần thiết.</strong> Không nên tổ chức meeting để báo kết quả có thể gửi Slack - tốn thời gian cả team.
         </motion.div>
       </motion.div>
     </div>

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/14-tools.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/14-tools.tsx
@@ -6,25 +6,25 @@ const tools = [
   {
     name: 'Slack',
     tips: [
-      'Dung thread de tra loi - tranh lam noise channel chinh',
-      'Dat status khi ban busy / khong co mat',
-      'Dung @mention dung nguoi, tranh @channel khi khong can thiet',
+      'Dùng thread để trả lời - tránh làm noise channel chính',
+      'Đặt status khi bận busy / không có mặt',
+      'Dùng @mention đúng người, tránh @channel khi không cần thiết',
     ],
   },
   {
     name: 'Jira / Ticket',
     tips: [
-      'Cap nhat trang thai ticket hang ngay',
-      'Ghi ro comment khi bi block hoac co change',
-      'Lien ket PR vao ticket de team theo doi',
+      'Cập nhật trạng thái ticket hàng ngày',
+      'Ghi rõ comment khi bị block hoặc có change',
+      'Liên kết PR vào ticket để team theo dõi',
     ],
   },
   {
     name: 'GitHub / GitLab',
     tips: [
-      'PR description day du: what, why, how to test',
-      'Review comment cu the, co suggestion code neu co the',
-      'Reply tat ca comment khi da xu ly xong',
+      'PR description đầy đủ: what, why, how to test',
+      'Review comment cụ thể, có suggestion code nếu có thể',
+      'Reply tất cả comment khi đã xử lý xong',
     ],
   },
 ]
@@ -84,7 +84,7 @@ export function Slide14Tools() {
             marginBottom: 28,
           }}
         >
-          Dung <span style={{ color: theme.colors.accent }}>tools hieu qua</span>
+          Dùng <span style={{ color: theme.colors.accent }}>tools hiệu quả</span>
         </motion.h2>
 
         <motion.div

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/15-code-review.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/15-code-review.tsx
@@ -3,9 +3,9 @@ import { theme } from '../lib/theme'
 import { container, fadeInUp } from '../lib/animations'
 
 const reviewerTips = [
-  { good: 'Suggestion: Co the dung Map thay vi for loop de tang hieu suat - O(n) -> O(1)', bad: 'Sai roi, viet lai di' },
-  { good: 'Nit: Dat ten bien ro rang hon: `u` -> `user` giup code de doc hon', bad: 'u la gi vay?' },
-  { good: 'Question: Minh thay curious tai sao chon approach nay? Co alternative khong?', bad: 'Tai sao lam vay?' },
+  { good: 'Suggestion: Có thể dùng Map thay vì for loop để tăng hiệu suất - O(n) -> O(1)', bad: 'Sai rồi, viết lại đi' },
+  { good: 'Nit: Đặt tên biến rõ ràng hơn: `u` -> `user` giúp code dễ đọc hơn', bad: 'u là gì vậy?' },
+  { good: 'Question: Mình thấy curious tại sao chọn approach này? Có alternative không?', bad: 'Tại sao làm vậy?' },
 ]
 
 export function Slide15CodeReview() {
@@ -63,7 +63,7 @@ export function Slide15CodeReview() {
             marginBottom: 8,
           }}
         >
-          Giao tiep trong <span style={{ color: theme.colors.accent }}>code review</span>
+          Giao tiếp trong <span style={{ color: theme.colors.accent }}>code review</span>
         </motion.h2>
 
         <motion.p
@@ -74,7 +74,7 @@ export function Slide15CodeReview() {
             marginBottom: 28,
           }}
         >
-          Code review la ve <strong>code</strong>, khong phai ve <strong>con nguoi</strong>. Phan bien code, khong phan bien tac gia.
+          Code review là về <strong>code</strong>, không phải về <strong>con người</strong>. Phản biện code, không phản biện tác giả.
         </motion.p>
 
         <motion.div
@@ -85,10 +85,10 @@ export function Slide15CodeReview() {
         >
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 4 }}>
             <div style={{ fontSize: theme.sizes.small, fontWeight: 700, color: theme.colors.positive }}>
-              Comment tot (Constructive)
+              Comment tốt (Constructive)
             </div>
             <div style={{ fontSize: theme.sizes.small, fontWeight: 700, color: theme.colors.negative }}>
-              Comment nen tranh
+              Comment nên tránh
             </div>
           </div>
 
@@ -140,7 +140,7 @@ export function Slide15CodeReview() {
             color: theme.colors.text,
           }}
         >
-          <strong style={{ color: theme.colors.accent }}>Label comment:</strong> "Nit" = khong bat buoc, "Blocker" = phai sua truoc khi merge, "Question" = minh muon hieu them.
+          <strong style={{ color: theme.colors.accent }}>Label comment:</strong> "Nit" = không bắt buộc, "Blocker" = phải sửa trước khi merge, "Question" = mình muốn hiểu thêm.
         </motion.div>
       </motion.div>
     </div>

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/16-senior-mentor.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/16-senior-mentor.tsx
@@ -3,18 +3,18 @@ import { theme } from '../lib/theme'
 import { container, fadeInUp, containerFast } from '../lib/animations'
 
 const dos = [
-  'Hoi sau khi tu tim hieu - cho thay ban da no luc truoc',
-  'Neu ro context va nhung gi da thu khi hoi',
-  'Ghi chep lai cau tra loi - tranh hoi cung mot cau nhieu lan',
-  'Cap nhat tien do cho mentor khong can doi ho hoi',
-  'Cam on cu the: "Cam on, nhung dieu do giup minh hieu..."',
+  'Hỏi sau khi tự tìm hiểu - cho thấy bạn đã nỗ lực trước',
+  'Nêu rõ context và những gì đã thử khi hỏi',
+  'Ghi chép lại câu trả lời - tránh hỏi cùng một câu nhiều lần',
+  'Cập nhật tiến độ cho mentor không cần đợi họ hỏi',
+  'Cảm ơn cụ thể: "Cảm ơn, những điều đó giúp mình hiểu..."',
 ]
 
 const donts = [
-  'Hoi cau hoi qua mo khong co context: "Em khong hieu gi het"',
-  'Im lang khi bi ket, ngai hoi vi so phien',
-  'Nhan hang het ma khong phan hoi hay dat cau hoi lai',
-  'Quen mat nhung gi da duoc chi dao, phai hoi lai',
+  'Hỏi câu hỏi quá mơ không có context: "Em không hiểu gì hết"',
+  'Im lặng khi bị kẹt, ngại hỏi vì sợ phiền',
+  'Nhận hàng hết mà không phản hồi hay đặt câu hỏi lại',
+  'Quên mất những gì đã được chỉ đạo, phải hỏi lại',
 ]
 
 export function Slide16SeniorMentor() {
@@ -72,7 +72,7 @@ export function Slide16SeniorMentor() {
             marginBottom: 28,
           }}
         >
-          Giao tiep voi <span style={{ color: theme.colors.accent }}>senior / mentor</span>
+          Giao tiếp với <span style={{ color: theme.colors.accent }}>senior / mentor</span>
         </motion.h2>
 
         <motion.div
@@ -81,7 +81,7 @@ export function Slide16SeniorMentor() {
         >
           <motion.div variants={fadeInUp}>
             <div style={{ fontSize: theme.sizes.small, fontWeight: 700, color: theme.colors.positive, marginBottom: 12 }}>
-              Nen lam
+              Nên làm
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               {dos.map((tip, i) => (
@@ -108,7 +108,7 @@ export function Slide16SeniorMentor() {
 
           <motion.div variants={fadeInUp}>
             <div style={{ fontSize: theme.sizes.small, fontWeight: 700, color: theme.colors.negative, marginBottom: 12 }}>
-              Tranh lam
+              Tránh làm
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               {donts.map((tip, i) => (

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/17-lien-phong-ban.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/17-lien-phong-ban.tsx
@@ -5,15 +5,15 @@ import { container, fadeInUp, containerFast } from '../lib/animations'
 const teams = [
   {
     team: 'QA / Tester',
-    tips: ['Mo ta ro steps to reproduce khi bao bug', 'Thong bao khi deploy len staging de QA test', 'Hoi ro acceptance criteria truoc khi lam'],
+    tips: ['Mô tả rõ steps to reproduce khi báo bug', 'Thông báo khi deploy lên staging để QA test', 'Hỏi rõ acceptance criteria trước khi làm'],
   },
   {
     team: 'Product / PM',
-    tips: ['Hoi ve "why" cua feature, khong chi "what"', 'Bao ngay khi co risk liem quan den deadline', 'Propose solution, khong chi neu van de'],
+    tips: ['Hỏi về "why" của feature, không chỉ "what"', 'Báo ngay khi có risk liên quan đến deadline', 'Propose solution, không chỉ nêu vấn đề'],
   },
   {
     team: 'DevOps / Infra',
-    tips: ['Tao ticket ro rang khi can infra support', 'Bao truoc khi can resource moi (server, config)', 'Follow process deploy - khong tu y deploy len prod'],
+    tips: ['Tạo ticket rõ ràng khi cần infra support', 'Báo trước khi cần resource mới (server, config)', 'Follow process deploy - không tự ý deploy lên prod'],
   },
 ]
 
@@ -72,7 +72,7 @@ export function Slide17LienPhongBan() {
             marginBottom: 28,
           }}
         >
-          Giao tiep <span style={{ color: theme.colors.accent }}>lien phong ban</span>
+          Giao tiếp <span style={{ color: theme.colors.accent }}>liên phòng ban</span>
         </motion.h2>
 
         <motion.div
@@ -144,7 +144,7 @@ export function Slide17LienPhongBan() {
             color: theme.colors.text,
           }}
         >
-          <strong style={{ color: theme.colors.accent }}>Nguyen tac chung:</strong> Moi team co ngon ngu rieng - tu do context, muc do uu tien. Hieu nguoi doc truoc khi viet.
+          <strong style={{ color: theme.colors.accent }}>Nguyên tắc chung:</strong> Mỗi team có ngôn ngữ riêng - từ đó context, mức độ ưu tiên. Hiểu người đọc trước khi viết.
         </motion.div>
       </motion.div>
     </div>

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/18-loi-pho-bien.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/18-loi-pho-bien.tsx
@@ -4,28 +4,28 @@ import { container, fadeInUp, containerFast } from '../lib/animations'
 
 const mistakes = [
   {
-    mistake: 'Im lang vi so phien',
-    fix: 'Hoi la bieu hien cua su chu dong, khong phai yeu kem',
+    mistake: 'Im lặng vì sợ phiền',
+    fix: 'Hỏi là biểu hiện của sự chủ động, không phải yếu kém',
   },
   {
-    mistake: 'Giu blocker "cho tu giai quyet"',
-    fix: 'Quy tac 15 phut: tu debug roi bao ngay neu chua xong',
+    mistake: 'Giữ blocker "chờ tự giải quyết"',
+    fix: 'Quy tắc 15 phút: tự debug rồi báo ngay nếu chưa xong',
   },
   {
-    mistake: 'Bao "Xong roi" khi chua test',
-    fix: '"Done" = lam xong + test + review ready',
+    mistake: 'Báo "Xong rồi" khi chưa test',
+    fix: '"Done" = làm xong + test + review ready',
   },
   {
-    mistake: 'Khong doc ki yeu cau truoc khi hoi',
-    fix: 'Doc ticket, doc doc, roi hoi - tranh hoi nhung gi da co san',
+    mistake: 'Không đọc kỹ yêu cầu trước khi hỏi',
+    fix: 'Đọc ticket, đọc doc, rồi hỏi - tránh hỏi những gì đã có sẵn',
   },
   {
-    mistake: 'Viet message dai dong, khong co point',
-    fix: 'BLUF: ket luan truoc, chi tiet sau, toi da 5 dong',
+    mistake: 'Viết message dài dòng, không có point',
+    fix: 'BLUF: kết luận trước, chi tiết sau, tối đa 5 dòng',
   },
   {
-    mistake: 'Khong confirm sau khi nhan task',
-    fix: 'Lap lai yeu cau bang loi cua minh de xac nhan hieu dung',
+    mistake: 'Không confirm sau khi nhận task',
+    fix: 'Lặp lại yêu cầu bằng lời của mình để xác nhận hiểu đúng',
   },
 ]
 
@@ -84,7 +84,7 @@ export function Slide18LoiPhoBien() {
             marginBottom: 24,
           }}
         >
-          Nhung loi giao tiep <span style={{ color: theme.colors.negative }}>pho bien</span> cua junior
+          Những lỗi giao tiếp <span style={{ color: theme.colors.negative }}>phổ biến</span> của junior
         </motion.h2>
 
         <motion.div
@@ -114,7 +114,7 @@ export function Slide18LoiPhoBien() {
                   alignItems: 'center',
                 }}
               >
-                <span style={{ opacity: 0.7 }}>Loi:</span> {item.mistake}
+                <span style={{ opacity: 0.7 }}>Lỗi:</span> {item.mistake}
               </div>
               <div
                 style={{

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/19-checklist.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/19-checklist.tsx
@@ -3,24 +3,24 @@ import { theme } from '../lib/theme'
 import { container, fadeInUp, containerFast } from '../lib/animations'
 
 const morning = [
-  'Doc Slack / email: co tin nhan nao can tra loi gap khong?',
-  'Check Jira: ticket cua minh co update gi khong?',
-  'Xac dinh 1-3 viec chinh can hoan thanh hom nay',
-  'Chuan bi cho daily standup: hom qua - hom nay - blocker',
+  'Đọc Slack / email: có tin nhắn nào cần trả lời gấp không?',
+  'Check Jira: ticket của mình có update gì không?',
+  'Xác định 1-3 việc chính cần hoàn thành hôm nay',
+  'Chuẩn bị cho daily standup: hôm qua - hôm nay - blocker',
 ]
 
 const during = [
-  'Cap nhat ticket khi bat dau hoac hoan thanh task',
-  'Neu gap blocker qua 15 phut: bao ngay',
-  'Reply comment PR / Slack trong vong hop ly (2-4h)',
-  'Ghi note neu nhan thong tin quan trong qua meeting / call',
+  'Cập nhật ticket khi bắt đầu hoặc hoàn thành task',
+  'Nếu gặp blocker quá 15 phút: báo ngay',
+  'Reply comment PR / Slack trong vòng hợp lý (2-4h)',
+  'Ghi note nếu nhận thông tin quan trọng qua meeting / call',
 ]
 
 const end = [
-  'Cap nhat trang thai cac ticket dang lam',
-  'Notify neu co gi chua hoan thanh theo ke hoach',
-  'Dong PR review chua xu ly xong',
-  'Clear notification va unread messages quan trong',
+  'Cập nhật trạng thái các ticket đang làm',
+  'Notify nếu có gì chưa hoàn thành theo kế hoạch',
+  'Đóng PR review chưa xử lý xong',
+  'Clear notification và unread messages quan trọng',
 ]
 
 export function Slide19Checklist() {
@@ -78,7 +78,7 @@ export function Slide19Checklist() {
             marginBottom: 24,
           }}
         >
-          Checklist giao tiep <span style={{ color: theme.colors.accent }}>hang ngay</span>
+          Checklist giao tiếp <span style={{ color: theme.colors.accent }}>hàng ngày</span>
         </motion.h2>
 
         <motion.div
@@ -86,9 +86,9 @@ export function Slide19Checklist() {
           style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 18 }}
         >
           {[
-            { label: 'Buoi sang', items: morning, color: '#d97706' },
-            { label: 'Trong ngay', items: during, color: theme.colors.accent },
-            { label: 'Cuoi ngay', items: end, color: theme.colors.positive },
+            { label: 'Buổi sáng', items: morning, color: '#d97706' },
+            { label: 'Trong ngày', items: during, color: theme.colors.accent },
+            { label: 'Cuối ngày', items: end, color: theme.colors.positive },
           ].map((col) => (
             <motion.div
               key={col.label}

--- a/slides/giao-tiep-hieu-qua-trong-team/src/slides/20-tong-ket.tsx
+++ b/slides/giao-tiep-hieu-qua-trong-team/src/slides/20-tong-ket.tsx
@@ -3,17 +3,17 @@ import { theme } from '../lib/theme'
 import { container, fadeInUp, containerFast } from '../lib/animations'
 
 const keyTakeaways = [
-  'Lang nghe de hieu, khong chi de tra loi',
-  'Bao som khi co van de - dung doi den khi "qua muon"',
-  'Viet ro rang: BLUF, context, action needed',
-  'Xac nhan lai de tranh hieu lam - dac biet sau meeting',
-  'Code review la ve code, khong phai ve con nguoi',
+  'Lắng nghe để hiểu, không chỉ để trả lời',
+  'Báo sớm khi có vấn đề - đừng đợi đến khi "quá muộn"',
+  'Viết rõ ràng: BLUF, context, action needed',
+  'Xác nhận lại để tránh hiểu lầm - đặc biệt sau meeting',
+  'Code review là về code, không phải về con người',
 ]
 
 const actions = [
-  'Chuan bi kip thoi cho standup ngay mai',
-  'Reply tat ca comment PR con boc trong hom nay',
-  'Dat cau hoi dung cach cho blocker hien tai',
+  'Chuẩn bị kịp thời cho standup ngày mai',
+  'Reply tất cả comment PR còn bỏ trong hôm nay',
+  'Đặt câu hỏi đúng cách cho blocker hiện tại',
 ]
 
 export function Slide20TongKet() {
@@ -82,7 +82,7 @@ export function Slide20TongKet() {
             marginBottom: 16,
           }}
         >
-          Slide 20 - Tong ket
+          Slide 20 - Tổng kết
         </motion.div>
 
         <motion.h2
@@ -95,7 +95,7 @@ export function Slide20TongKet() {
             lineHeight: 1.15,
           }}
         >
-          5 dieu can <span style={{ color: theme.colors.accent }}>nho mai</span>
+          5 điều cần <span style={{ color: theme.colors.accent }}>nhớ mãi</span>
         </motion.h2>
 
         <motion.div variants={fadeInUp} style={{ width: 40, height: 2, background: theme.colors.accent, marginBottom: 24 }} />
@@ -188,7 +188,7 @@ export function Slide20TongKet() {
               letterSpacing: '0.1em',
             }}
           >
-            Hanh dong ngay hom nay
+            Hành động ngay hôm nay
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             {actions.map((action, i) => (
@@ -222,7 +222,7 @@ export function Slide20TongKet() {
           }}
         >
           <div style={{ fontSize: theme.sizes.small, color: theme.colors.textMuted, lineHeight: 1.7, fontStyle: 'italic' }}>
-            "Giao tiep tot khong phai la noi nhieu. Do la kha nang khien nguoi khac hieu minh va minh hieu nguoi khac - mot each ro rang, nhanh chong, hieu qua."
+            "Giao tiếp tốt không phải là nói nhiều. Đó là khả năng khiến người khác hiểu mình và mình hiểu người khác - một cách rõ ràng, nhanh chóng, hiệu quả."
           </div>
         </motion.div>
 


### PR DESCRIPTION
Closes #7

STATUS: IMPLEMENTED

Jira issue: https://ignify-rd.atlassian.net/browse/RD-994
Repository: https://github.com/ignify-rd/public-slides

Summary: Sửa tiếng Việt trong deck “Giao tiếp hiệu quả trong team”

## Plan

## Summary

Two fixes to the `giao-tiep-hieu-qua-trong-team` deck:

1. **Vietnamese diacritics** — every slide file under `slides/giao-tiep-hieu-qua-trong-team/src/slides/` contains unaccented Vietnamese (e.g. `"ro rang, ngan gon"`, `"ket luan truoc"`). Replace all such strings with fully-accented Vietnamese across all 20 slide files (`01-title.tsx` … `20-tong-ket.tsx`).

2. **Plain-text link in slide 07** — `07-viet-message.tsx` renders the message example inside a `fontFamily: 'monospace'` code-block div. The GitHub link (`github.com/org/repo/pull/142`) and the surrounding message body should be displayed as plain text, not inside a code-quote styled container. Remove or replace the monospace/code-block styling from that example box so the content renders as normal readable text.

## Implementation steps

1. Go through each of the 20 `src/slides/*.tsx` files and rewrite every Vietnamese string to include correct tone marks and diacritics.
2. In `07-viet-message.tsx`, change the inner message `<div>` from `fontFamily: 'monospace'` + code-block background/border styling to plain paragraph styling (normal font, no background, no border, or minimal neutral styling that doesn't imply "code").
3. Build locally (`npm ci && npx tsc --noEmit && npx vite build` inside the deck directory) to confirm no TypeScript errors and assets resolve correctly.
4. Open a PR targeting `main`; CI will rebuild docs/ automatically.

## Files to change

- `slides/giao-tiep-hieu-qua-trong-team/src/slides/01-title.tsx` … `20-tong-ket.tsx` (all 20 files — diacritics)
- `slides/giao-tiep-hieu-qua-trong-team/src/slides/07-viet-message.tsx` (also remove code-block styling from message example)