### PR TITLE
fix: Fix Vietnamese accents in ai-era-human-role slide deck [RD-999]

### DIFF
--- a/slides/ai-era-human-role/src/slides/01-title.tsx
+++ b/slides/ai-era-human-role/src/slides/01-title.tsx
@@ -83,9 +83,9 @@ export function Slide01Title() {
             marginBottom: 32,
           }}
         >
-          Con nguoi trong
+          Con người trong
           <br />
-          <span style={{ color: theme.colors.accent }}>ky nguyen AI</span>
+          <span style={{ color: theme.colors.accent }}>kỷ nguyên AI</span>
         </motion.h1>
 
         <motion.div
@@ -107,7 +107,7 @@ export function Slide01Title() {
             maxWidth: 420,
           }}
         >
-          AI viet code ngay cang nhieu. Vai tro cua lap trinh vien thay doi nhu the nao?
+          AI viết code ngày càng nhiều. Vai trò của lập trình viên thay đổi như thế nào?
         </motion.p>
       </motion.div>
 

--- a/slides/ai-era-human-role/src/slides/02-adoption.tsx
+++ b/slides/ai-era-human-role/src/slides/02-adoption.tsx
@@ -69,9 +69,9 @@ export function Slide02Adoption() {
             marginBottom: 32,
           }}
         >
-          46% code tren GitHub
+          46% code trên GitHub
           <br />
-          <span style={{ color: theme.colors.accent }}>duoc viet boi AI</span>
+          <span style={{ color: theme.colors.accent }}>được viết bởi AI</span>
         </motion.h2>
 
         <motion.p
@@ -84,8 +84,8 @@ export function Slide02Adoption() {
             marginBottom: 24,
           }}
         >
-          GitHub Octoverse 2023: trong so code duoc accept qua Copilot,
-          gan mot nua la do AI sinh ra. Ty le nay dang tang nhanh.
+          GitHub Octoverse 2023: trong số code được accept qua Copilot,
+          gần một nửa là do AI sinh ra. Tỷ lệ này đang tăng nhanh.
         </motion.p>
 
         <motion.div
@@ -96,7 +96,7 @@ export function Slide02Adoption() {
             fontStyle: 'italic',
           }}
         >
-          Nguon: GitHub Octoverse 2023 Report
+          Nguồn: GitHub Octoverse 2023 Report
         </motion.div>
       </motion.div>
 
@@ -139,7 +139,7 @@ export function Slide02Adoption() {
               maxWidth: 200,
             }}
           >
-            code duoc sinh boi AI (GitHub Copilot)
+            code được sinh bởi AI (GitHub Copilot)
           </div>
         </motion.div>
       </div>

--- a/slides/ai-era-human-role/src/slides/03-productivity.tsx
+++ b/slides/ai-era-human-role/src/slides/03-productivity.tsx
@@ -4,9 +4,9 @@ import { container, fadeInUp } from '../lib/animations'
 
 export function Slide03Productivity() {
   const stats = [
-    { value: '55%', label: 'nhanh hon khi viet code (GitHub study, 2023)' },
-    { value: '74%', label: 'lap trinh vien cam thay it met hon (GitHub survey)' },
-    { value: '2x', label: 'so luong PR merge tren tuan (Stripe AI pilot)' },
+    { value: '55%', label: 'nhanh hơn khi viết code (GitHub study, 2023)' },
+    { value: '74%', label: 'lập trình viên cảm thấy ít mệt hơn (GitHub survey)' },
+    { value: '2x', label: 'số lượng PR merge trên tuần (Stripe AI pilot)' },
   ]
 
   return (
@@ -56,7 +56,7 @@ export function Slide03Productivity() {
             marginBottom: 32,
           }}
         >
-          Nang suat
+          Năng suất
         </motion.div>
 
         <motion.h2
@@ -69,9 +69,9 @@ export function Slide03Productivity() {
             marginBottom: 48,
           }}
         >
-          AI tang toc do lap trinh
+          AI tăng tốc độ lập trình
           <br />
-          <span style={{ color: theme.colors.positive }}>ro rang va co the do luong</span>
+          <span style={{ color: theme.colors.positive }}>rõ ràng và có thể đo lường</span>
         </motion.h2>
 
         <div style={{ display: 'flex', gap: 32 }}>
@@ -129,7 +129,7 @@ export function Slide03Productivity() {
           fontStyle: 'italic',
         }}
       >
-        Nguon: GitHub (2023), Stripe internal report
+        Nguồn: GitHub (2023), Stripe internal report
       </motion.div>
     </div>
   )

--- a/slides/ai-era-human-role/src/slides/04-but.tsx
+++ b/slides/ai-era-human-role/src/slides/04-but.tsx
@@ -6,15 +6,15 @@ export function Slide04But() {
   const issues = [
     {
       title: 'Hallucination',
-      desc: 'AI bịa API không ton tai. Stanford: 52% Copilot suggestions co loi bao mat tiềm ẩn.',
+      desc: 'AI bịa API không tồn tại. Stanford: 52% Copilot suggestions có lỗi bảo mật tiềm ẩn.',
     },
     {
       title: 'Wrong context',
-      desc: 'AI không biet business logic, lich su thay doi, hay constraint cua he thong.',
+      desc: 'AI không biết business logic, lịch sử thay đổi, hay constraint của hệ thống.',
     },
     {
       title: 'Cascading bugs',
-      desc: 'Bug do AI tao ra kho debug hon - dev khong hieu code minh merge.',
+      desc: 'Bug do AI tạo ra khó debug hơn - dev không hiểu code mình merge.',
     },
   ]
 
@@ -64,7 +64,7 @@ export function Slide04But() {
             marginBottom: 16,
           }}
         >
-          Nhung...
+          Nhưng...
         </motion.div>
 
         <motion.h2
@@ -76,7 +76,7 @@ export function Slide04But() {
             marginBottom: 40,
           }}
         >
-          Nang suat cao hon khong co nghia la it loi hon.
+          Năng suất cao hơn không có nghĩa là ít lỗi hơn.
         </motion.h2>
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
@@ -145,7 +145,7 @@ export function Slide04But() {
           fontStyle: 'italic',
         }}
       >
-        Nguon: Stanford HAI (2023) - "Do GitHub Copilot introduce bugs?"
+        Nguồn: Stanford HAI (2023) - "Do GitHub Copilot introduce bugs?"
       </motion.div>
     </div>
   )

--- a/slides/ai-era-human-role/src/slides/05-intent.tsx
+++ b/slides/ai-era-human-role/src/slides/05-intent.tsx
@@ -40,7 +40,7 @@ export function Slide05Intent() {
             marginBottom: 32,
           }}
         >
-          Goc nhin quan trong
+          Góc nhìn quan trọng
         </motion.div>
 
         <motion.h2
@@ -53,8 +53,8 @@ export function Slide05Intent() {
             marginBottom: 32,
           }}
         >
-          AI khong hieu{' '}
-          <span style={{ color: theme.colors.accent }}>y dinh</span>
+          AI không hiểu{' '}
+          <span style={{ color: theme.colors.accent }}>ý định</span>
           <br />
           cua ban
         </motion.h2>
@@ -69,8 +69,8 @@ export function Slide05Intent() {
             marginBottom: 28,
           }}
         >
-          AI toi uu hoa de tao ra code "co ve dung" - khong phai code "dung voi nhu cau cu the".
-          No khong biet: tai sao feature nay ton tai, ai su dung, dieu gi se xay ra neu logic sai.
+          AI tối ưu hóa để tạo ra code "có vẻ đúng" - không phải code "đúng với nhu cầu cụ thể".
+          Nó không biết: tại sao feature này tồn tại, ai sử dụng, điều gì sẽ xảy ra nếu logic sai.
         </motion.p>
 
         <motion.div
@@ -86,8 +86,8 @@ export function Slide05Intent() {
             maxWidth: 430,
           }}
         >
-          Code review khong phai la kiem tra syntax -
-          la kiem tra <strong>xem AI co hieu dung bai toan khong.</strong>
+          Code review không phải là kiểm tra syntax -
+          là kiểm tra <strong>xem AI có hiểu đúng bài toán không.</strong>
         </motion.div>
       </motion.div>
 
@@ -128,11 +128,11 @@ export function Slide05Intent() {
           }}
         >
           {[
-            { label: 'AI biet', value: 'Syntax + patterns' },
-            { label: 'AI biet', value: 'Training data (den 2024)' },
-            { label: 'AI khong biet', value: 'Business domain' },
-            { label: 'AI khong biet', value: 'System constraints' },
-            { label: 'AI khong biet', value: 'User needs' },
+            { label: 'AI biết', value: 'Syntax + patterns' },
+            { label: 'AI biết', value: 'Training data (đến 2024)' },
+            { label: 'AI không biết', value: 'Business domain' },
+            { label: 'AI không biết', value: 'System constraints' },
+            { label: 'AI không biết', value: 'User needs' },
           ].map((row, i) => (
             <motion.div
               key={i}
@@ -149,7 +149,7 @@ export function Slide05Intent() {
                 style={{
                   fontSize: theme.sizes.small,
                   fontWeight: 700,
-                  color: row.label === 'AI biet' ? theme.colors.positive : theme.colors.negative,
+                  color: row.label === 'AI biết' ? theme.colors.positive : theme.colors.negative,
                   minWidth: 100,
                 }}
               >

--- a/slides/ai-era-human-role/src/slides/06-sentiment.tsx
+++ b/slides/ai-era-human-role/src/slides/06-sentiment.tsx
@@ -61,7 +61,7 @@ export function Slide06Sentiment() {
             marginBottom: 32,
           }}
         >
-          Tin hieu tu cong dong
+          Tín hiệu từ cộng đồng
         </motion.div>
 
         <motion.h2
@@ -74,7 +74,7 @@ export function Slide06Sentiment() {
             marginBottom: 40,
           }}
         >
-          Dev danh nhieu thoi gian hon
+          Dev dành nhiều thời gian hơn
           <br />
           <span style={{ color: theme.colors.accent }}>review AI output</span>
         </motion.h2>
@@ -132,7 +132,7 @@ export function Slide06Sentiment() {
           fontStyle: 'italic',
         }}
       >
-        Nguon: Stack Overflow Dev Survey 2024, Reddit r/ExperiencedDevs
+        Nguồn: Stack Overflow Dev Survey 2024, Reddit r/ExperiencedDevs
       </motion.div>
     </div>
   )

--- a/slides/ai-era-human-role/src/slides/07-bottleneck.tsx
+++ b/slides/ai-era-human-role/src/slides/07-bottleneck.tsx
@@ -51,7 +51,7 @@ export function Slide07Bottleneck() {
             marginBottom: 40,
           }}
         >
-          Bottleneck moi
+          Bottleneck mới
         </motion.div>
 
         <motion.div
@@ -64,9 +64,9 @@ export function Slide07Bottleneck() {
             marginBottom: 24,
           }}
         >
-          Doc va kiem tra AI code
+          Đọc và kiểm tra AI code
           <br />
-          <span style={{ color: theme.colors.warning }}>mat thoi gian hon la viet.</span>
+          <span style={{ color: theme.colors.warning }}>mất thời gian hơn là viết.</span>
         </motion.div>
 
         <motion.div
@@ -79,16 +79,16 @@ export function Slide07Bottleneck() {
             margin: '0 auto 40px',
           }}
         >
-          Khi AI tao ra 10x nhieu code hon, khong phai la "review nhanh hon" -
-          ma la review nhieu hon, sau hon. Developer khong chet vi viet code,
-          ma chet vi khong du thoi gian kiem tra.
+          Khi AI tạo ra 10x nhiều code hơn, không phải là "review nhanh hơn" -
+          mà là review nhiều hơn, sâu hơn. Developer không chết vì viết code,
+          mà chết vì không đủ thời gian kiểm tra.
         </motion.div>
 
         {/* Before / After */}
         <div style={{ display: 'flex', gap: 24, justifyContent: 'center' }}>
           {[
-            { label: 'Truoc AI', value: 'Viet > Review', color: theme.colors.textMuted },
-            { label: 'Sau AI', value: 'Review > Viet', color: theme.colors.warning },
+            { label: 'Trước AI', value: 'Viết > Review', color: theme.colors.textMuted },
+            { label: 'Sau AI', value: 'Review > Viết', color: theme.colors.warning },
           ].map((item) => (
             <motion.div
               key={item.label}

--- a/slides/ai-era-human-role/src/slides/08-role-shift.tsx
+++ b/slides/ai-era-human-role/src/slides/08-role-shift.tsx
@@ -7,17 +7,17 @@ export function Slide08RoleShift() {
     {
       from: 'Author',
       to: 'Reviewer',
-      desc: 'Kiem tra AI output, phan tich loi va edge case',
+      desc: 'Kiểm tra AI output, phân tích lỗi và edge case',
     },
     {
       from: 'Coder',
       to: 'Architect',
-      desc: 'Thiet ke he thong, quyet dinh phan chia module',
+      desc: 'Thiết kế hệ thống, quyết định phân chia module',
     },
     {
       from: 'Implementer',
       to: 'Prompt engineer',
-      desc: 'Dien dat yeu cau chinh xac de AI sinh ra dung code',
+      desc: 'Diễn đạt yêu cầu chính xác để AI sinh ra đúng code',
     },
   ]
 
@@ -68,7 +68,7 @@ export function Slide08RoleShift() {
             marginBottom: 32,
           }}
         >
-          Vai tro thay doi
+          Vai trò thay đổi
         </motion.div>
 
         <motion.h2
@@ -81,9 +81,9 @@ export function Slide08RoleShift() {
             marginBottom: 40,
           }}
         >
-          Tu <span style={{ color: theme.colors.textMuted }}>nguoi viet</span>{' '}
+          Từ <span style={{ color: theme.colors.textMuted }}>người viết</span>{' '}
           sang{' '}
-          <span style={{ color: theme.colors.accent }}>nguoi kien tao</span>
+          <span style={{ color: theme.colors.accent }}>người kiến tạo</span>
         </motion.h2>
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>

--- a/slides/ai-era-human-role/src/slides/09-human-skills.tsx
+++ b/slides/ai-era-human-role/src/slides/09-human-skills.tsx
@@ -7,22 +7,22 @@ export function Slide09HumanSkills() {
     {
       icon: '🏗',
       title: 'System design',
-      desc: 'Quyet dinh kien truc, trade-off, scalability - AI chỉ co biet pattern.',
+      desc: 'Quyết định kiến trúc, trade-off, scalability - AI chỉ có biết pattern.',
     },
     {
       icon: '🐛',
-      title: 'Debug loi phuc tap',
-      desc: 'Loi xay ra tu su ket hop cua nhieu he thong, khong co trong training data.',
+      title: 'Debug lỗi phức tạp',
+      desc: 'Lỗi xảy ra từ sự kết hợp của nhiều hệ thống, không có trong training data.',
     },
     {
       icon: '🤝',
-      title: 'Giao tiep voi stakeholder',
-      desc: 'Hieu yeu cau mo ho, dam phan scope, dieu phoi giua team va khach hang.',
+      title: 'Giao tiếp với stakeholder',
+      desc: 'Hiểu yêu cầu mơ hồ, đàm phán scope, điều phối giữa team và khách hàng.',
     },
     {
       icon: '⚖',
-      title: 'Quyet dinh dao duc / rui ro',
-      desc: 'Chon giai phap phu hop voi boi canh to chuc, phap ly, nguoi dung.',
+      title: 'Quyết định đạo đức / rủi ro',
+      desc: 'Chọn giải pháp phù hợp với bối cảnh tổ chức, pháp lý, người dùng.',
     },
   ]
 
@@ -73,7 +73,7 @@ export function Slide09HumanSkills() {
             marginBottom: 24,
           }}
         >
-          Nhung gi van can con nguoi
+          Những gì vẫn cần con người
         </motion.div>
 
         <motion.h2
@@ -85,7 +85,7 @@ export function Slide09HumanSkills() {
             marginBottom: 32,
           }}
         >
-          AI chua the thay the duoc
+          AI chưa thể thay thế được
         </motion.h2>
 
         <div

--- a/slides/ai-era-human-role/src/slides/10-more-work.tsx
+++ b/slides/ai-era-human-role/src/slides/10-more-work.tsx
@@ -50,7 +50,7 @@ export function Slide10MoreWork() {
             marginBottom: 32,
           }}
         >
-          Hieu lam pho bien
+          Hiểu lầm phổ biến
         </motion.div>
 
         <motion.h2
@@ -63,8 +63,8 @@ export function Slide10MoreWork() {
             marginBottom: 32,
           }}
         >
-          AI tang output -{' '}
-          <span style={{ color: theme.colors.warning }}>trach nhiem khong giam</span>
+          AI tăng output -{' '}
+          <span style={{ color: theme.colors.warning }}>trách nhiệm không giảm</span>
         </motion.h2>
 
         <div style={{ display: 'flex', gap: 32 }}>
@@ -82,13 +82,13 @@ export function Slide10MoreWork() {
                 letterSpacing: '0.1em',
               }}
             >
-              Tang
+              Tăng
             </div>
             {[
-              'So dong code duoc tao ra',
-              'So feature duoc deliver',
-              'So PR duoc mo',
-              'So edge case tiềm an',
+              'Số dòng code được tạo ra',
+              'Số feature được deliver',
+              'Số PR được mở',
+              'Số edge case tiềm ẩn',
             ].map((item, i) => (
               <motion.div
                 key={item}
@@ -151,13 +151,13 @@ export function Slide10MoreWork() {
                 letterSpacing: '0.1em',
               }}
             >
-              Khong thay doi
+              Không thay đổi
             </div>
             {[
-              'Trach nhiem voi bug production',
-              'Yeu cau khi on-call',
-              'Security va compliance',
-              'Kỳ vong tu stakeholder',
+              'Trách nhiệm với bug production',
+              'Yêu cầu khi on-call',
+              'Security và compliance',
+              'Kỳ vọng từ stakeholder',
             ].map((item, i) => (
               <motion.div
                 key={item}

--- a/slides/ai-era-human-role/src/slides/11-conclusion.tsx
+++ b/slides/ai-era-human-role/src/slides/11-conclusion.tsx
@@ -62,7 +62,7 @@ export function Slide11Conclusion() {
           marginBottom: 40,
         }}
       >
-        Ket luan
+        Kết luận
       </motion.div>
 
       <motion.div
@@ -77,7 +77,7 @@ export function Slide11Conclusion() {
           marginBottom: 16,
         }}
       >
-        Thich nghi,
+        Thích nghi,
       </motion.div>
 
       <motion.div
@@ -91,8 +91,8 @@ export function Slide11Conclusion() {
           marginBottom: 8,
         }}
       >
-        dung{' '}
-        <span style={{ color: theme.colors.negative }}>bien mat.</span>
+        đừng{' '}
+        <span style={{ color: theme.colors.negative }}>biến mất.</span>
       </motion.div>
 
       <motion.div
@@ -107,10 +107,10 @@ export function Slide11Conclusion() {
           lineHeight: 1.7,
         }}
       >
-        AI thay doi cach chung ta lam viec - khong thay chung ta.
+        AI thay đổi cách chúng ta làm việc - không thay chúng ta.
         <br />
-        Nguoi nam vung review, kien truc, va giao tiep
-        se tro nen <strong style={{ color: theme.colors.text }}>gia tri hon</strong>, khong phai it hon.
+        Người nắm vững review, kiến trúc, và giao tiếp
+        sẽ trở nên <strong style={{ color: theme.colors.text }}>giá trị hơn</strong>, không phải ít hơn.
       </motion.div>
 
       <motion.div
@@ -125,7 +125,7 @@ export function Slide11Conclusion() {
           justifyContent: 'center',
         }}
       >
-        {['Hieu AI', 'Kien tao he thong', 'Giao tiep tot', 'Chiu trach nhiem'].map((tag, i) => (
+        {['Hiểu AI', 'Kiến tạo hệ thống', 'Giao tiếp tốt', 'Chịu trách nhiệm'].map((tag, i) => (
           <motion.span
             key={tag}
             initial={{ opacity: 0, scale: 0.9 }}


### PR DESCRIPTION
Closes #13

STATUS: IMPLEMENTED

Jira issue: https://ignify-rd.atlassian.net/browse/RD-999
Repository: https://github.com/ignify-rd/public-slides

Summary: Fix Vietnamese language in slide deck ai-era-human-role to have accents

## Plan

## What

All Vietnamese text in `slides/ai-era-human-role/src/slides/` is written as plain ASCII (no diacritical marks). Replace every occurrence with properly accented Vietnamese.

## Affected files

- `src/slides/01-title.tsx` — subtitle body text
- `src/slides/02-adoption.tsx` — stat label
- `src/slides/03-productivity.tsx` — stat label (`nhanh hon khi viet code`)
- `src/slides/07-bottleneck.tsx` — body text and comparison labels
- `src/slides/08-role-shift.tsx` — role label (`nguoi viet`)
- Scan remaining slides (`04`–`06`, `09`–`11`) for any additional unaccented Vietnamese text

## Steps

1. Read each file in `slides/ai-era-human-role/src/slides/`.
2. Identify all Vietnamese strings missing accents.
3. Replace them with correct Vietnamese (e.g. `viết`, `hơn`, `vai trò`, `lập trình viên`, `mất thời gian`, `kiểm tra`, `trước/sau`).
4. Verify `npx tsc --noEmit && npx vite build` passes inside `slides/ai-era-human-role/`.

## Acceptance criteria

- No unaccented Vietnamese words remain in any `.tsx` source file under `slides/ai-era-human-role/`.
- TypeScript check and Vite build both pass.