### PR TITLE
fix: Điều tra và sửa lỗi CSS không render đúng trong rd-1106-ai-orchestration [RD-1111]

### DIFF
--- a/slides/rd-1106-ai-orchestration/src/components/EvolutionDiagram.tsx
+++ b/slides/rd-1106-ai-orchestration/src/components/EvolutionDiagram.tsx
@@ -6,37 +6,27 @@ const STEPS = [
   {
     label: 'Chatbot',
     icon: '💬',
-    gradientFrom: 'from-sky-500',
-    gradientTo: 'to-sky-700',
-    borderHighlight: 'border-sky-500',
+    highlightedClass: 'bg-gradient-to-br from-sky-500 to-sky-700 border-2 border-sky-500',
   },
   {
     label: 'AI Agent',
     icon: '🤖',
-    gradientFrom: 'from-violet-500',
-    gradientTo: 'to-violet-700',
-    borderHighlight: 'border-violet-500',
+    highlightedClass: 'bg-gradient-to-br from-violet-500 to-violet-700 border-2 border-violet-500',
   },
   {
     label: 'Personal AI',
     icon: '🧑‍💼',
-    gradientFrom: 'from-emerald-500',
-    gradientTo: 'to-emerald-700',
-    borderHighlight: 'border-emerald-500',
+    highlightedClass: 'bg-gradient-to-br from-emerald-500 to-emerald-700 border-2 border-emerald-500',
   },
   {
     label: 'AI Orchestration',
     icon: '🎼',
-    gradientFrom: 'from-orange-500',
-    gradientTo: 'to-orange-700',
-    borderHighlight: 'border-orange-500',
+    highlightedClass: 'bg-gradient-to-br from-orange-500 to-orange-700 border-2 border-orange-500',
   },
   {
     label: '?',
     icon: '✨',
-    gradientFrom: 'from-amber-400',
-    gradientTo: 'to-yellow-600',
-    borderHighlight: 'border-amber-400',
+    highlightedClass: 'bg-gradient-to-br from-amber-400 to-yellow-600 border-2 border-amber-400',
   },
 ]
 
@@ -52,7 +42,7 @@ export function EvolutionDiagram({ highlightedStage }: EvolutionDiagramProps) {
             <div
               className={`flex-1 flex flex-col items-center justify-center rounded-xl px-2 py-3 text-center transition-all duration-200
                 ${isHighlighted
-                  ? `bg-gradient-to-br ${step.gradientFrom} ${step.gradientTo} border-2 ${step.borderHighlight} text-white font-bold shadow-lg`
+                  ? `${step.highlightedClass} text-white font-bold shadow-lg`
                   : isDimmed
                     ? 'border border-gray-200 bg-gray-50 opacity-40'
                     : 'border border-gray-300 bg-white font-medium text-gray-700 hover:border-gray-400'

--- a/slides/rd-1106-ai-orchestration/src/index.css
+++ b/slides/rd-1106-ai-orchestration/src/index.css
@@ -1,11 +1,5 @@
 @import "tailwindcss";
 
-*, *::before, *::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
-
 html, body {
   width: 100%;
   height: 100%;

--- a/slides/rd-1106-ai-orchestration/src/slides/SlideEvolution.tsx
+++ b/slides/rd-1106-ai-orchestration/src/slides/SlideEvolution.tsx
@@ -6,8 +6,7 @@ const STAGE_CARDS = [
     icon: '💬',
     label: 'Chatbot',
     desc: 'Hỏi - đáp theo kịch bản định sẵn',
-    gradient: 'from-sky-50 to-sky-100',
-    border: 'border-sky-200',
+    gradientClass: 'bg-gradient-to-br from-sky-50 to-sky-100 border-sky-200',
     accent: 'text-sky-700',
     badge: 'bg-sky-500',
   },
@@ -15,8 +14,7 @@ const STAGE_CARDS = [
     icon: '🤖',
     label: 'AI Agent',
     desc: 'Tự lên kế hoạch và thực hiện nhiệm vụ',
-    gradient: 'from-violet-50 to-violet-100',
-    border: 'border-violet-200',
+    gradientClass: 'bg-gradient-to-br from-violet-50 to-violet-100 border-violet-200',
     accent: 'text-violet-700',
     badge: 'bg-violet-500',
   },
@@ -24,8 +22,7 @@ const STAGE_CARDS = [
     icon: '🧑‍💼',
     label: 'Personal AI',
     desc: 'Trợ lý cá nhân hóa sâu cho từng người',
-    gradient: 'from-emerald-50 to-emerald-100',
-    border: 'border-emerald-200',
+    gradientClass: 'bg-gradient-to-br from-emerald-50 to-emerald-100 border-emerald-200',
     accent: 'text-emerald-700',
     badge: 'bg-emerald-500',
   },
@@ -33,8 +30,7 @@ const STAGE_CARDS = [
     icon: '🎼',
     label: 'AI Orchestration',
     desc: 'Phối hợp nhiều AI Agent làm việc cùng nhau',
-    gradient: 'from-orange-50 to-orange-100',
-    border: 'border-orange-200',
+    gradientClass: 'bg-gradient-to-br from-orange-50 to-orange-100 border-orange-200',
     accent: 'text-orange-700',
     badge: 'bg-orange-500',
   },
@@ -42,8 +38,7 @@ const STAGE_CARDS = [
     icon: '✨',
     label: '?',
     desc: 'Giai đoạn tiếp theo - chưa ai biết trước',
-    gradient: 'from-amber-50 to-yellow-100',
-    border: 'border-amber-300',
+    gradientClass: 'bg-gradient-to-br from-amber-50 to-yellow-100 border-amber-300',
     accent: 'text-amber-700',
     badge: 'bg-amber-400',
   },
@@ -77,10 +72,10 @@ export function SlideEvolution({ highlightedStage }: SlideEvolutionProps) {
               key={stage.label}
               className={`flex-1 flex flex-col items-center justify-center rounded-2xl p-5 border-2 transition-all duration-200
                 ${isHighlighted
-                  ? `bg-gradient-to-br ${stage.gradient} ${stage.border} shadow-xl scale-105`
+                  ? `${stage.gradientClass} shadow-xl scale-105`
                   : isDimmed
-                    ? `bg-gray-50 border-gray-200 opacity-40`
-                    : `bg-gradient-to-br ${stage.gradient} ${stage.border}`
+                    ? 'bg-gray-50 border-gray-200 opacity-40'
+                    : stage.gradientClass
                 }`}
             >
               <span className="text-4xl mb-3">{stage.icon}</span>


### PR DESCRIPTION
Closes #32

STATUS: IMPLEMENTED

Jira issue: https://ignify-rd.atlassian.net/browse/RD-1111
Repository: https://github.com/ignify-rd/public-slides

Summary: CSS padding/spacing không được render — điều tra nguyên nhân gốc rễ và sửa

## Bối cảnh

Vấn đề không phải là giá trị padding thiếu. CSS không được render ra output, dẫn đến toàn bộ spacing biến mất. Đã xác định được hai nguyên nhân gốc rễ.

Branch làm việc: `rd-1106-ai-orchestration` (chưa merge vào main)

---

## Nguyên nhân gốc rễ (đã xác định)

### 1. Global CSS reset ghi đè padding (nguyên nhân chính)

CSS reset sau đây đang ghi đè toàn bộ padding/margin trên slide elements:

```css
*, :before, :after {
    box-sizing: border-box;
    margin: 0;
    padding: 0;
}
```

Rule này (thường đến từ Tailwind preflight hoặc một global stylesheet) xóa sạch mọi padding/margin — kể cả các class Tailwind như `p-12`, `p-4` nếu chúng có specificity thấp hơn hoặc bị apply sau.

### 2. Dynamic class construction bị Tailwind purge

Trong `EvolutionDiagram.tsx`, Tailwind classes được tạo động qua template literal:

```tsx
`bg-gradient-to-br ${step.gradientFrom} ${step.gradientTo}`
```

Các giá trị như `from-sky-500`, `to-sky-700` được lưu trong object properties, không phải literal string trong JSX — Tailwind không thể scan và sẽ purge chúng khỏi build output.

### 3. Không có `tailwind.config.ts` với content paths rõ ràng

Deck dùng Tailwind CSS v4 qua `@tailwindcss/vite` nhưng không có `tailwind.config.ts`. Tailwind v4 tự động detect content, tuy nhiên khi kết hợp với dynamic classes, các class không được tạo static sẽ bị bỏ qua.

---

## Các bước sửa

### Bước 1: Xác định nguồn gốc CSS reset

Tìm file đang inject `*, :before, :after { margin: 0; padding: 0; }`:
- Kiểm tra `src/index.css`, `src/main.tsx`, `src/App.tsx`
- Kiểm tra xem Tailwind preflight có đang được bật không
- Xác định xem reset có cần thiết không, hay có thể disable/scope lại

### Bước 2: Sửa CSS reset override

Tùy theo nguồn gốc:
- **Nếu từ Tailwind preflight**: Cân nhắc disable preflight (`@layer base { ... }` overrides) hoặc thêm lại padding trong một layer cụ thể
- **Nếu từ global CSS file**: Scope reset để không ảnh hưởng đến slide content elements, hoặc dùng `!important` cho các utility class cần thiết
- **Cách đơn giản nhất**: Đảm bảo các slide container/elements có Tailwind utilities với specificity đủ cao để override reset

### Bước 3: Kiểm tra build output

Kiểm tra xem class nào thực sự có trong CSS đã build:
- Build deck: `npm ci && npx vite build`
- Inspect `dist/assets/*.css` — xác nhận class như `p-12`, `from-sky-500` có trong file không

### Bước 4: Sửa dynamic class trong `EvolutionDiagram.tsx`

Chuyển từ dynamic template literals sang static class strings:

```tsx
// Trước (bị purge):
`bg-gradient-to-br ${step.gradientFrom} ${step.gradientTo}`

// Sau (static, Tailwind scan được):
gradientClass: "bg-gradient-to-br from-sky-500 to-sky-700"
```

Hoặc dùng `safelist` trong config nếu cần giữ pattern động.

### Bước 5: Kiểm tra toàn bộ components còn lại

Scan tất cả files trong `src/components/` tìm pattern dynamic class:
- Template literals: `` `${variable}` ``
- String concatenation: `"p-" + size`
- Conditional nối chuỗi không phải literal

Files cần kiểm tra:
- `EvolutionDiagram.tsx` — đã xác nhận có vấn đề
- `SlidesReveal.tsx`, `SlidesReveal03.tsx`
- `SlidesOrchestration.tsx`, `SlidesChatbot.tsx`
- `SlideWrapper.tsx` — xác nhận `p-12` static

### Bước 6: Thêm `tailwind.config.ts` (nếu cần)

Nếu sau Bước 4-5 vẫn còn class bị thiếu, thêm explicit content config:

```ts
// tailwind.config.ts
export default {
  content: [
    './index.html',
    './src/**/*.{js,ts,jsx,tsx}',
  ],
}
```

### Bước 7: Verify build pass

```bash
npx tsc --noEmit && npx vite build
```

Inspect CSS output xác nhận các spacing/padding classes có mặt đầy đủ.

---

## Tiêu chí hoàn thành

- [ ] Xác định file/rule CSS reset đang ghi đè padding và sửa hoặc scope lại
- [ ] Xác định đầy đủ danh sách dynamic class patterns bị purge
- [ ] Sửa tất cả dynamic class thành static hoặc thêm vào safelist
- [ ] Build output CSS chứa các class spacing cần thiết (`p-12`, `p-4`, `p-5`, gradient classes, v.v.)
- [ ] Build pass: `npx tsc --noEmit && npx vite build` không có lỗi
- [ ] Slides hiển thị đúng spacing trong browser (không cần thay đổi giá trị, chỉ cần CSS được render)