### PR TITLE
fix: Thêm dấu tiếng Việt vào slide data-fabric-de-hieu [RD-1113]

### DIFF
--- a/slides/data-fabric-de-hieu/src/slides/01-title.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/01-title.tsx
@@ -161,7 +161,7 @@ export function Slide01Title() {
           }}
         >
           <span style={{ color: 'white', fontSize: theme.sizes.body, fontWeight: 600 }}>
-            De hieu - Thuc te - Ung dung ngay
+            Dễ hiểu - Thực tế - Ứng dụng ngay
           </span>
         </motion.div>
 
@@ -175,9 +175,9 @@ export function Slide01Title() {
             fontStyle: 'italic',
           }}
         >
-          Tai lieu nay thuoc pham vi luu hanh noi bo va khong duoc phep sao chep,
-          cung cap, tiet lo hoac chia se cho bat ky ben thu ba nao ngoai to chuc,
-          tru truong hop da duoc cap phep truoc bang van ban.
+          Tài liệu này thuộc phạm vi lưu hành nội bộ và không được phép sao chép,
+          cung cấp, tiết lộ hoặc chia sẻ cho bất kỳ bên thứ ba nào ngoài tổ chức,
+          trừ trường hợp đã được cấp phép trước bằng văn bản.
         </motion.p>
       </motion.div>
 

--- a/slides/data-fabric-de-hieu/src/slides/02-section-why.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/02-section-why.tsx
@@ -81,7 +81,7 @@ export function Slide02SectionWhy() {
             letterSpacing: '-0.02em',
           }}
         >
-          Tai sao can{' '}
+          Tại sao cần{' '}
           <span style={{ color: theme.colors.accent }}>Data Fabric?</span>
         </motion.h2>
         <motion.div

--- a/slides/data-fabric-de-hieu/src/slides/03-diagram-silos.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/03-diagram-silos.tsx
@@ -46,7 +46,7 @@ export function Slide03DiagramSilos() {
             marginBottom: 10,
           }}
         >
-          Thuc trang hien tai
+          Thực trạng hiện tại
         </div>
         <h2
           style={{
@@ -56,7 +56,7 @@ export function Slide03DiagramSilos() {
             letterSpacing: '-0.02em',
           }}
         >
-          Du lieu phan tan - khong ket noi
+          Dữ liệu phân tán - không kết nối
         </h2>
       </motion.div>
 
@@ -159,7 +159,7 @@ export function Slide03DiagramSilos() {
             <line x1="12" y1="9" x2="12" y2="13"/>
             <line x1="12" y1="17" x2="12.01" y2="17"/>
           </svg>
-          Khong "noi chuyen" duoc voi nhau
+          Không "nói chuyện" được với nhau
         </motion.div>
       </motion.div>
     </div>

--- a/slides/data-fabric-de-hieu/src/slides/04-why-content.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/04-why-content.tsx
@@ -4,9 +4,9 @@ import { container, fadeInUp, scaleIn } from '../lib/animations'
 
 const locations = [
   { icon: '📊', label: 'trong file Excel' },
-  { icon: '☁', label: 'tren cloud' },
-  { icon: '🗄', label: 'trong co so du lieu cu' },
-  { icon: '🏢', label: 'o cac phong ban khac nhau' },
+  { icon: '☁', label: 'trên cloud' },
+  { icon: '🗄', label: 'trong cơ sở dữ liệu cũ' },
+  { icon: '🏢', label: 'ở các phòng ban khác nhau' },
 ]
 
 export function Slide04WhyContent() {
@@ -60,7 +60,7 @@ export function Slide04WhyContent() {
                 marginBottom: 10,
               }}
             >
-              Van de
+              Vấn đề
             </div>
             <h2
               style={{
@@ -71,7 +71,7 @@ export function Slide04WhyContent() {
                 letterSpacing: '-0.02em',
               }}
             >
-              Tai sao can{' '}
+              Tại sao cần{' '}
               <span style={{ color: theme.colors.accent }}>Data Fabric?</span>
             </h2>
           </motion.div>
@@ -85,7 +85,7 @@ export function Slide04WhyContent() {
                 marginBottom: 16,
               }}
             >
-              Du lieu cua ban nam rai rac khap noi:
+              Dữ liệu của bạn nằm rải rác khắp nơi:
             </p>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 20 }}>
               {locations.map((loc, i) => (
@@ -117,7 +117,7 @@ export function Slide04WhyContent() {
                 fontStyle: 'italic',
               }}
             >
-              Thuong thi rat lon xon.
+              Thường thì rất lộn xộn.
             </p>
             <p
               style={{
@@ -127,8 +127,8 @@ export function Slide04WhyContent() {
                 marginTop: 10,
               }}
             >
-              Moi nguoi mat thoi gian tim du lieu dung, sao chep qua lai,
-              va sua cho lech nhau.
+              Mọi người mất thời gian tìm dữ liệu đúng, sao chép qua lại,
+              và sửa cho lệch nhau.
             </p>
           </motion.div>
         </motion.div>
@@ -190,7 +190,7 @@ export function Slide04WhyContent() {
                 marginBottom: 10,
               }}
             >
-              Giai phap
+              Giải pháp
             </div>
             <p
               style={{
@@ -201,7 +201,7 @@ export function Slide04WhyContent() {
                 marginBottom: 12,
               }}
             >
-              Data fabric giong nhu mot <em>smart layer</em> phu len cac he thong do.
+              Data fabric giống như một <em>smart layer</em> phủ lên các hệ thống đó.
             </p>
             <p
               style={{
@@ -210,7 +210,7 @@ export function Slide04WhyContent() {
                 lineHeight: 1.7,
               }}
             >
-              No giup ket noi, sap xep, va lam du lieu de tim, de dung hon.
+              Nó giúp kết nối, sắp xếp, và làm dữ liệu dễ tìm, dễ dùng hơn.
             </p>
           </div>
         </motion.div>

--- a/slides/data-fabric-de-hieu/src/slides/05-challenges.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/05-challenges.tsx
@@ -5,32 +5,32 @@ import { container, fadeInUp, scaleIn } from '../lib/animations'
 const challenges = [
   {
     icon: '🏢',
-    title: 'Su co lap du lieu (Data Silos)',
-    desc: 'Du lieu nam rai rac o nhieu phong ban, ung dung khac nhau va khong "noi chuyen" duoc voi nhau.',
+    title: 'Sự cô lập dữ liệu (Data Silos)',
+    desc: 'Dữ liệu nằm rải rác ở nhiều phòng ban, ứng dụng khác nhau và không "nói chuyện" được với nhau.',
     color: '#DC2626',
   },
   {
     icon: '☁',
-    title: 'Moi truong phuc tap (Hybrid & Multi-cloud)',
-    desc: 'Du lieu vua o duoi server cong ty (On-premise), vua o tren nhieu nen tang may (AWS, Azure, Google Cloud), gay kho khan khi muon tong hop.',
+    title: 'Môi trường phức tạp (Hybrid & Multi-cloud)',
+    desc: 'Dữ liệu vừa ở dưới server công ty (On-premise), vừa ở trên nhiều nền tảng mây (AWS, Azure, Google Cloud), gây khó khăn khi muốn tổng hợp.',
     color: '#D97706',
   },
   {
     icon: '⏱',
-    title: 'Quy trinh thu cong & Cham tre',
-    desc: 'Viec lay du lieu mat vai tuan vi phai cho IT viet code, chay ETL (chiet xuat, bien doi, nap) thu cong.',
+    title: 'Quy trình thủ công & Chậm trễ',
+    desc: 'Việc lấy dữ liệu mất vài tuần vì phải chờ IT viết code, chạy ETL (chiết xuất, biến đổi, nạp) thủ công.',
     color: '#7C3AED',
   },
   {
     icon: '🌑',
-    title: 'Du lieu "toi" (Dark Data)',
-    desc: 'Doanh nghiep co rat nhieu du lieu nhung khong biet minh dang co gi, du lieu do co dang tin hay khong (thieu Metadata).',
+    title: 'Dữ liệu "tối" (Dark Data)',
+    desc: 'Doanh nghiệp có rất nhiều dữ liệu nhưng không biết mình đang có gì, dữ liệu đó có đáng tin hay không (thiếu Metadata).',
     color: '#0F172A',
   },
   {
     icon: '🔒',
-    title: 'Rui ro bao mat',
-    desc: 'Cang nhieu nguon du lieu thi cang kho kiem soat ai dang xem cai gi, de vi pham quy dinh phap luat (nhu GDPR).',
+    title: 'Rủi ro bảo mật',
+    desc: 'Càng nhiều nguồn dữ liệu thì càng khó kiểm soát ai đang xem cái gì, dễ vi phạm quy định pháp luật (như GDPR).',
     color: '#059669',
   },
 ]
@@ -67,7 +67,7 @@ export function Slide05Challenges() {
               marginBottom: 10,
             }}
           >
-            Boi canh
+            Bối cảnh
           </div>
           <h2
             style={{
@@ -78,7 +78,7 @@ export function Slide05Challenges() {
               letterSpacing: '-0.02em',
             }}
           >
-            Kho khan chung cua viec quan ly du lieu
+            Khó khăn chung của việc quản lý dữ liệu
           </h2>
         </motion.div>
 

--- a/slides/data-fabric-de-hieu/src/slides/06-quote.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/06-quote.tsx
@@ -81,7 +81,7 @@ export function Slide06Quote() {
             letterSpacing: '-0.01em',
           }}
         >
-          Trong ky nguyen AI, mot nguon du lieu tin cay duy nhat{' '}
+          Trong kỷ nguyên AI, một nguồn dữ liệu tin cậy duy nhất{' '}
           <span
             style={{
               background: 'rgba(255,255,255,0.2)',
@@ -92,11 +92,11 @@ export function Slide06Quote() {
           >
             (Single Source of Truth)
           </span>{' '}
-          chinh la{' '}
+          chính là{' '}
           <span style={{ color: '#FDE68A', fontWeight: 800 }}>
             'xuong song'
           </span>{' '}
-          giup doanh nghiep van hanh chinh xac va hieu qua.
+          giúp doanh nghiệp vận hành chính xác và hiệu quả.
         </p>
 
         <motion.div
@@ -142,7 +142,7 @@ export function Slide06Quote() {
           </svg>
         </div>
         <span style={{ color: 'rgba(255,255,255,0.7)', fontSize: '0.75rem', fontWeight: 500, letterSpacing: '0.1em' }}>
-          Nen tang cho AI era
+          Nền tảng cho AI era
         </span>
       </motion.div>
     </div>

--- a/slides/data-fabric-de-hieu/src/slides/07-section-solution.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/07-section-solution.tsx
@@ -77,8 +77,8 @@ export function Slide07SectionSolution() {
             letterSpacing: '-0.02em',
           }}
         >
-          Xu ly{' '}
-          <span style={{ color: theme.colors.accent }}>the nao?</span>
+          Xử lý{' '}
+          <span style={{ color: theme.colors.accent }}>thế nào?</span>
         </motion.h2>
         <motion.div
           initial={{ scaleX: 0 }}

--- a/slides/data-fabric-de-hieu/src/slides/08-diagram-fabric.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/08-diagram-fabric.tsx
@@ -41,7 +41,7 @@ export function Slide08DiagramFabric() {
         >
           Data Fabric:{' '}
           <span style={{ color: theme.colors.accent }}>Smart Layer</span>{' '}
-          ket noi moi nguon
+          kết nối mọi nguồn
         </h2>
       </motion.div>
 

--- a/slides/data-fabric-de-hieu/src/slides/09-data-context.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/09-data-context.tsx
@@ -34,7 +34,7 @@ export function Slide09DataContext() {
               marginBottom: 10,
             }}
           >
-            Diem manh nhất
+            Điểm mạnh nhất
           </div>
           <h2
             style={{
@@ -45,7 +45,7 @@ export function Slide09DataContext() {
               letterSpacing: '-0.02em',
             }}
           >
-            Diem "dat" nhat cua Data Fabric:
+            Điểm "đắt" nhất của Data Fabric:
             <br />
             <span style={{ color: theme.colors.accent }}>Data</span>
             {' -> '}
@@ -65,7 +65,7 @@ export function Slide09DataContext() {
           {[
             {
               label: 'Raw Data',
-              sublabel: 'Du lieu tho',
+              sublabel: 'Dữ liệu thô',
               icon: '📦',
               bg: theme.colors.accentDim,
               border: theme.colors.borderAccent,
@@ -74,7 +74,7 @@ export function Slide09DataContext() {
             null,
             {
               label: 'Metadata',
-              sublabel: 'Sieu du lieu',
+              sublabel: 'Siêu dữ liệu',
               icon: '🏷',
               bg: '#FEF3C720',
               border: '#D97706',
@@ -83,7 +83,7 @@ export function Slide09DataContext() {
             null,
             {
               label: 'Knowledge Graph',
-              sublabel: 'Do thi tri thuc',
+              sublabel: 'Đồ thị tri thức',
               icon: '🕸',
               bg: '#F0FDF430',
               border: theme.colors.accentGreen,
@@ -92,7 +92,7 @@ export function Slide09DataContext() {
             null,
             {
               label: 'Context',
-              sublabel: 'Ngu canh / Y nghia',
+              sublabel: 'Ngữ cảnh / Ý nghĩa',
               icon: '💡',
               bg: '#F0F9FF30',
               border: theme.colors.accentAlt,
@@ -178,8 +178,8 @@ export function Slide09DataContext() {
               lineHeight: 1.6,
             }}
           >
-            Data Fabric khong chi luu tru du lieu - no hieu du lieu do co y nghia gi,
-            lien quan den cai gi, va co the su dung nhu the nao.
+            Data Fabric không chỉ lưu trữ dữ liệu - nó hiểu dữ liệu đó có ý nghĩa gì,
+            liên quan đến cái gì, và có thể sử dụng như thế nào.
           </p>
         </motion.div>
       </motion.div>

--- a/slides/data-fabric-de-hieu/src/slides/10-diagram-layers.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/10-diagram-layers.tsx
@@ -65,7 +65,7 @@ export function Slide10DiagramLayers() {
             letterSpacing: '-0.02em',
           }}
         >
-          Kien truc phan tang cua Data Fabric
+          Kiến trúc phân tầng của Data Fabric
         </h2>
       </motion.div>
 

--- a/slides/data-fabric-de-hieu/src/slides/11-section-location.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/11-section-location.tsx
@@ -78,7 +78,7 @@ export function Slide11SectionLocation() {
           }}
         >
           Data Fabric{' '}
-          <span style={{ color: theme.colors.accent }}>nam o dau?</span>
+          <span style={{ color: theme.colors.accent }}>nằm ở đâu?</span>
         </motion.h2>
         <motion.div
           initial={{ scaleX: 0 }}

--- a/slides/data-fabric-de-hieu/src/slides/12-diagram-architecture.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/12-diagram-architecture.tsx
@@ -40,7 +40,7 @@ export function Slide12DiagramArchitecture() {
             letterSpacing: '-0.02em',
           }}
         >
-          Cong ty su dung Data Fabric - Truoc va Sau
+          Công ty sử dụng Data Fabric - Trước và Sau
         </h2>
       </motion.div>
 
@@ -63,7 +63,7 @@ export function Slide12DiagramArchitecture() {
               marginBottom: 16,
             }}
           >
-            Truoc (Khong co Fabric)
+            Trước (Không có Fabric)
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             {departments.map((dept, i) => (
@@ -108,7 +108,7 @@ export function Slide12DiagramArchitecture() {
               fontStyle: 'italic',
             }}
           >
-            Moi phong ban dung ten cot khac nhau - khong noi chuyen duoc!
+            Mỗi phòng ban dùng tên cột khác nhau - không nói chuyện được!
           </div>
         </div>
 
@@ -161,7 +161,7 @@ export function Slide12DiagramArchitecture() {
               marginBottom: 16,
             }}
           >
-            Sau (Co Data Fabric)
+            Sau (Có Data Fabric)
           </div>
           <motion.div
             variants={scaleIn}
@@ -194,7 +194,7 @@ export function Slide12DiagramArchitecture() {
             >
               base_pay = Salary_USD = Income = gross_salary
               <br />
-              Fabric nhan dang tat ca la mot truong du lieu
+              Fabric nhận dạng tất cả là một trường dữ liệu
             </div>
             {departments.map((dept, i) => (
               <div
@@ -221,7 +221,7 @@ export function Slide12DiagramArchitecture() {
               fontStyle: 'italic',
             }}
           >
-            Mot nguon nhin thong nhat - nhat quan, chinh xac!
+            Một nguồn nhìn thống nhất - nhất quán, chính xác!
           </div>
         </div>
       </motion.div>

--- a/slides/data-fabric-de-hieu/src/slides/13-diagram-components.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/13-diagram-components.tsx
@@ -6,37 +6,37 @@ const components = [
   {
     icon: '🔮',
     title: 'Data Virtualization',
-    desc: 'Truy cap du lieu tai nguon goc, khong can sao chep vat ly',
+    desc: 'Truy cập dữ liệu tại nguồn gốc, không cần sao chép vật lý',
     color: theme.colors.accent,
   },
   {
     icon: '🏷',
     title: 'Metadata Management',
-    desc: 'Quan ly sieu du lieu, phan loai va tag tu dong bang AI',
+    desc: 'Quản lý siêu dữ liệu, phân loại và tag tự động bằng AI',
     color: '#7C3AED',
   },
   {
     icon: '🔗',
     title: 'Data Lineage',
-    desc: 'Truy vet nguon goc du lieu: den tu dau, qua nhung buoc nao',
+    desc: 'Truy vết nguồn gốc dữ liệu: đến từ đâu, qua những bước nào',
     color: theme.colors.accentAlt,
   },
   {
     icon: '🛡',
     title: 'Data Governance',
-    desc: 'Chinh sach truy cap, bao mat, va tuan thu quy dinh phap ly',
+    desc: 'Chính sách truy cập, bảo mật, và tuân thủ quy định pháp lý',
     color: '#059669',
   },
   {
     icon: '🤖',
     title: 'AI/ML Orchestration',
-    desc: 'Ket hop AI de tu dong hoa cac quy trinh quan ly du lieu',
+    desc: 'Kết hợp AI để tự động hóa các quy trình quản lý dữ liệu',
     color: '#D97706',
   },
   {
     icon: '📡',
     title: 'Real-time Integration',
-    desc: 'Dong bo du lieu theo thoi gian thuc tu nhieu nguon',
+    desc: 'Đồng bộ dữ liệu theo thời gian thực từ nhiều nguồn',
     color: '#DC2626',
   },
 ]
@@ -71,7 +71,7 @@ export function Slide13DiagramComponents() {
             letterSpacing: '-0.02em',
           }}
         >
-          Cac thanh phan cot loi cua Data Fabric
+          Các thành phần cốt lõi của Data Fabric
         </h2>
       </motion.div>
 

--- a/slides/data-fabric-de-hieu/src/slides/14-section-problems.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/14-section-problems.tsx
@@ -77,8 +77,8 @@ export function Slide14SectionProblems() {
             letterSpacing: '-0.02em',
           }}
         >
-          Nhung van de{' '}
-          <span style={{ color: theme.colors.accent }}>thuong phai xu ly</span>
+          Những vấn đề{' '}
+          <span style={{ color: theme.colors.accent }}>thường phải xử lý</span>
         </motion.h2>
         <motion.div
           initial={{ scaleX: 0 }}

--- a/slides/data-fabric-de-hieu/src/slides/15-diagram-problems.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/15-diagram-problems.tsx
@@ -5,30 +5,30 @@ import { container, scaleIn, fadeInUp } from '../lib/animations'
 const problems = [
   {
     icon: '⚠',
-    title: 'Du lieu mai thuan',
-    scenario: 'Phong Sales: luong = 15M VND, Phong Ke toan: luong = 18M VND',
-    cause: 'Hai he thong dung don vi khac nhau (gross vs net)',
+    title: 'Dữ liệu mâu thuẫn',
+    scenario: 'Phòng Sales: lương = 15M VND, Phòng Kế toán: lương = 18M VND',
+    cause: 'Hai hệ thống dùng đơn vị khác nhau (gross vs net)',
     color: '#DC2626',
   },
   {
     icon: '🕒',
-    title: 'Tre do - Du lieu cu',
-    scenario: 'Bao cao hom nay dung du lieu cua... tuan truoc',
-    cause: 'Pipeline ETL chay batch hang dem, khong phai real-time',
+    title: 'Trễ độ - Dữ liệu cũ',
+    scenario: 'Báo cáo hôm nay dùng dữ liệu của... tuần trước',
+    cause: 'Pipeline ETL chạy batch hằng đêm, không phải real-time',
     color: '#D97706',
   },
   {
     icon: '🚫',
-    title: 'Truy cap sai pham',
-    scenario: 'Nhan vien co the xem luong cua toan cong ty',
-    cause: 'Chua co chinh sach phan quyen du lieu theo phong ban',
+    title: 'Truy cập sai phạm',
+    scenario: 'Nhân viên có thể xem lương của toàn công ty',
+    cause: 'Chưa có chính sách phân quyền dữ liệu theo phòng ban',
     color: '#7C3AED',
   },
   {
     icon: '❓',
-    title: 'Khong biet du lieu den tu dau',
-    scenario: 'Con so "doanh thu Q3" nay lay tu bao cao nao?',
-    cause: 'Khong co Data Lineage de truy vet nguon goc',
+    title: 'Không biết dữ liệu đến từ đâu',
+    scenario: 'Con số "doanh thu Q3" này lấy từ báo cáo nào?',
+    cause: 'Không có Data Lineage để truy vết nguồn gốc',
     color: '#0EA5E9',
   },
 ]
@@ -63,7 +63,7 @@ export function Slide15DiagramProblems() {
             letterSpacing: '-0.02em',
           }}
         >
-          Cac van de thuong gap trong thuc te
+          Các vấn đề thường gặp trong thực tế
         </h2>
       </motion.div>
 
@@ -136,7 +136,7 @@ export function Slide15DiagramProblems() {
                 </div>
               </div>
               <div style={{ display: 'flex', gap: 6, alignItems: 'flex-start' }}>
-                <span style={{ color: prob.color, fontSize: '0.75rem', flexShrink: 0 }}>Nguyen nhan:</span>
+                <span style={{ color: prob.color, fontSize: '0.75rem', flexShrink: 0 }}>Nguyên nhân:</span>
                 <span style={{ fontSize: '0.68rem', color: theme.colors.textMuted, lineHeight: 1.5 }}>
                   {prob.cause}
                 </span>

--- a/slides/data-fabric-de-hieu/src/slides/16-diagram-resolution.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/16-diagram-resolution.tsx
@@ -4,30 +4,30 @@ import { container, scaleIn, fadeInUp } from '../lib/animations'
 
 const resolutions = [
   {
-    problem: 'Du lieu mai thuan',
-    before: 'Sales: 15M, Ke toan: 18M',
-    after: 'Fabric chuan hoa: gross = 18M, net = 15M',
+    problem: 'Dữ liệu mâu thuẫn',
+    before: 'Sales: 15M, Kế toán: 18M',
+    after: 'Fabric chuẩn hóa: gross = 18M, net = 15M',
     solution: 'Business Rules Engine',
     color: '#DC2626',
   },
   {
-    problem: 'Du lieu tre do',
-    before: 'Bao cao dung du lieu tuan truoc',
-    after: 'Truy cap real-time tu nguon goc',
+    problem: 'Dữ liệu trễ độ',
+    before: 'Báo cáo dùng dữ liệu tuần trước',
+    after: 'Truy cập real-time từ nguồn gốc',
     solution: 'Data Virtualization',
     color: '#D97706',
   },
   {
-    problem: 'Truy cap sai pham',
-    before: 'Moi nguoi xem duoc tat ca',
-    after: 'Phan quyen theo vai tro (RBAC)',
+    problem: 'Truy cập sai phạm',
+    before: 'Mọi người xem được tất cả',
+    after: 'Phân quyền theo vai trò (RBAC)',
     solution: 'Data Governance Layer',
     color: '#7C3AED',
   },
   {
-    problem: 'Khong biet nguon goc',
-    before: 'Con so tu dau ra khong ro',
-    after: 'Truy vet duoc toan bo hanh trinh du lieu',
+    problem: 'Không biết nguồn gốc',
+    before: 'Con số từ đâu ra không rõ',
+    after: 'Truy vết được toàn bộ hành trình dữ liệu',
     solution: 'Data Lineage Tracking',
     color: '#0EA5E9',
   },
@@ -63,7 +63,7 @@ export function Slide16DiagramResolution() {
             letterSpacing: '-0.02em',
           }}
         >
-          Data Fabric giai quyet nhu the nao?
+          Data Fabric giải quyết như thế nào?
         </h2>
       </motion.div>
 
@@ -111,7 +111,7 @@ export function Slide16DiagramResolution() {
                 lineHeight: 1.4,
               }}
             >
-              <span style={{ fontWeight: 600 }}>Truoc: </span>{res.before}
+              <span style={{ fontWeight: 600 }}>Trước: </span>{res.before}
             </div>
             <div style={{ textAlign: 'center', color: theme.colors.accentGreen, fontWeight: 700 }}>
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">

--- a/slides/data-fabric-de-hieu/src/slides/17-resolution-methods.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/17-resolution-methods.tsx
@@ -5,20 +5,20 @@ import { container, fadeInUp, scaleIn } from '../lib/animations'
 const methods = [
   {
     icon: '🔍',
-    title: 'Phan tich Metadata (Lineage)',
-    desc: 'No kiem tra xem du lieu nay den tu dau. He thong SQL chinh thuc thuong duoc may cham diem tin cay cao hon mot tep Excel nhap tay.',
+    title: 'Phân tích Metadata (Lineage)',
+    desc: 'Nó kiểm tra xem dữ liệu này đến từ đâu. Hệ thống SQL chính thức thường được máy chấm điểm tin cậy cao hơn một tệp Excel nhập tay.',
     color: theme.colors.accent,
   },
   {
     icon: '📋',
-    title: 'Ap dung Quy tac kinh doanh (Business Rules)',
-    desc: 'Ban co the cai dat: "Neu co sai lech ve luong, luon uu tien du lieu tu he thong Ke toan". Quy tac nay duoc ap dung tu dong cho moi truy van.',
+    title: 'Áp dụng Quy tắc kinh doanh (Business Rules)',
+    desc: 'Bạn có thể cài đặt: "Nếu có sai lệch về lương, luôn ưu tiên dữ liệu từ hệ thống Kế toán". Quy tắc này được áp dụng tự động cho mọi truy vấn.',
     color: '#7C3AED',
   },
   {
     icon: '🤖',
-    title: 'Hoc may (AI/ML)',
-    desc: 'AI quan sat lich su chinh sua. Neu no thay tep Excel thuong xuyen bi sai va da duoc sua lai nhieu lan, no se tu dong canh bao day la nguon du lieu "kem chat luong".',
+    title: 'Học máy (AI/ML)',
+    desc: 'AI quan sát lịch sử chỉnh sửa. Nếu nó thấy tệp Excel thường xuyên bị sai và đã được sửa lại nhiều lần, nó sẽ tự động cảnh báo đây là nguồn dữ liệu "kém chất lượng".',
     color: theme.colors.accentGreen,
   },
 ]
@@ -71,7 +71,7 @@ export function Slide17ResolutionMethods() {
               marginBottom: 10,
             }}
           >
-            Co che xu ly sai lech
+            Cơ chế xử lý sai lệch
           </div>
           <h2
             style={{
@@ -82,7 +82,7 @@ export function Slide17ResolutionMethods() {
               letterSpacing: '-0.02em',
             }}
           >
-            Cach Data Fabric xu ly sai lech
+            Cách Data Fabric xử lý sai lệch
           </h2>
         </motion.div>
 

--- a/slides/data-fabric-de-hieu/src/slides/18-section-example.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/18-section-example.tsx
@@ -77,8 +77,8 @@ export function Slide18SectionExample() {
             letterSpacing: '-0.02em',
           }}
         >
-          Vi du{' '}
-          <span style={{ color: theme.colors.accent }}>minh hoa</span>
+          Ví dụ{' '}
+          <span style={{ color: theme.colors.accent }}>minh họa</span>
         </motion.h2>
         <motion.div
           initial={{ scaleX: 0 }}

--- a/slides/data-fabric-de-hieu/src/slides/19-example-content.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/19-example-content.tsx
@@ -4,23 +4,23 @@ import { container, fadeInUp, scaleIn } from '../lib/animations'
 
 const steps = [
   {
-    step: 'Buoc 1',
-    title: 'Ao hoa (Virtualization)',
-    desc: 'Ban khong can tai du lieu ve may. Data Fabric tao ra cac "pipelines" ket noi truc tiep den 3 nguon nay: SQL Server, Excel SharePoint, va SaaS.',
+    step: 'Bước 1',
+    title: 'Ảo hóa (Virtualization)',
+    desc: 'Bạn không cần tải dữ liệu về máy. Data Fabric tạo ra các "pipelines" kết nối trực tiếp đến 3 nguồn này: SQL Server, Excel SharePoint, và SaaS.',
     color: theme.colors.accent,
     icon: '🔌',
   },
   {
-    step: 'Buoc 2',
-    title: 'Thau hieu / AI',
-    desc: 'Bo nao AI cua Fabric nhan dien: "Du ten cot khac nhau va dinh gia tien te khac nhau, nhung tat ca deu mang nhan (tag) la #Salary". No tu dong quy doi USD ve VND dua tren ty gia moi nhat.',
+    step: 'Bước 2',
+    title: 'Thấu hiểu / AI',
+    desc: 'Bộ não AI của Fabric nhận diện: "Dù tên cột khác nhau và định giá tiền tệ khác nhau, nhưng tất cả đều mang nhãn (tag) là #Salary". Nó tự động quy đổi USD về VND dựa trên tỷ giá mới nhất.',
     color: '#7C3AED',
     icon: '🤖',
   },
   {
-    step: 'Buoc 3',
-    title: 'Ket noi Power BI',
-    desc: 'Ban chi can mo Power BI, chon mot nguon duy nhat la "Data Fabric - Employee View". Moi su sai lech da duoc Fabric xu ly. Bieu do hien ra ngay chieu nay.',
+    step: 'Bước 3',
+    title: 'Kết nối Power BI',
+    desc: 'Bạn chỉ cần mở Power BI, chọn một nguồn duy nhất là "Data Fabric - Employee View". Mọi sự sai lệch đã được Fabric xử lý. Biểu đồ hiện ra ngay chiều này.',
     color: theme.colors.accentGreen,
     icon: '📊',
   },
@@ -64,7 +64,7 @@ export function Slide19ExampleContent() {
           <div style={{ fontSize: '1.4rem', flexShrink: 0 }}>💬</div>
           <div>
             <div style={{ fontSize: '0.65rem', color: theme.colors.accent, fontWeight: 700, marginBottom: 4, textTransform: 'uppercase', letterSpacing: '0.1em' }}>
-              Yeu cau tu Manager
+              Yêu cầu từ Manager
             </div>
             <p
               style={{
@@ -75,7 +75,7 @@ export function Slide19ExampleContent() {
                 lineHeight: 1.55,
               }}
             >
-              "Hay cho toi xem bieu do luong trung binh toan tap doan tren Power BI ngay chieu nay."
+              "Hãy cho tôi xem biểu đồ lương trung bình toàn tập đoàn trên Power BI ngay chiều này."
             </p>
           </div>
         </motion.div>
@@ -94,11 +94,11 @@ export function Slide19ExampleContent() {
             lineHeight: 1.6,
           }}
         >
-          <strong>Kich ban:</strong> Phong Sales luu luong trong SQL Server (cot{' '}
+          <strong>Kịch bản:</strong> Phòng Sales lưu lương trong SQL Server (cột{' '}
           <code style={{ background: '#FEF3C7', padding: '1px 4px', borderRadius: 3 }}>base_pay</code>),
-          phong Tech luu trong file Excel tren SharePoint (cot{' '}
+          phòng Tech lưu trong file Excel trên SharePoint (cột{' '}
           <code style={{ background: '#FEF3C7', padding: '1px 4px', borderRadius: 3 }}>Salary_USD</code>),
-          phong Marketing dung phan mem SaaS (cot{' '}
+          phòng Marketing dùng phần mềm SaaS (cột{' '}
           <code style={{ background: '#FEF3C7', padding: '1px 4px', borderRadius: 3 }}>Income</code>).
         </motion.div>
 
@@ -182,7 +182,7 @@ export function Slide19ExampleContent() {
         >
           <span style={{ fontSize: '1.2rem' }}>✅</span>
           <span style={{ fontSize: '0.78rem', color: theme.colors.accentGreen, fontWeight: 600 }}>
-            Ket qua: Bieu do hien len ngay, du lieu nhat quan, chinh xac - va ban da lam xong truoc chieu!
+            Kết quả: Biểu đồ hiện lên ngay, dữ liệu nhất quán, chính xác - và bạn đã làm xong trước chiều!
           </span>
         </motion.div>
       </motion.div>

--- a/slides/data-fabric-de-hieu/src/slides/20-section-solutions.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/20-section-solutions.tsx
@@ -77,8 +77,8 @@ export function Slide20SectionSolutions() {
             letterSpacing: '-0.02em',
           }}
         >
-          Giai phap{' '}
-          <span style={{ color: theme.colors.accent }}>co san</span>
+          Giải pháp{' '}
+          <span style={{ color: theme.colors.accent }}>có sẵn</span>
         </motion.h2>
         <motion.div
           initial={{ scaleX: 0 }}

--- a/slides/data-fabric-de-hieu/src/slides/21-vendors-table.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/21-vendors-table.tsx
@@ -7,32 +7,32 @@ const vendors = [
     vendor: 'Microsoft',
     logo: '🪟',
     solution: 'Microsoft Fabric',
-    philosophy: 'Su don gian: Moi thu trong mot (All-in-one).',
-    strength: 'Tich hop sau voi Azure, Power BI, Office 365',
+    philosophy: 'Sự đơn giản: Mọi thứ trong một (All-in-one).',
+    strength: 'Tích hợp sâu với Azure, Power BI, Office 365',
     color: '#0078D4',
   },
   {
     vendor: 'IBM',
     logo: '🔵',
     solution: 'Cloud Pak for Data',
-    philosophy: 'Su thong minh: Dung AI quan tri metadata cuc sau.',
-    strength: 'AI Governance, Watson, do chin muoi cho enterprise',
+    philosophy: 'Sự thông minh: Dùng AI quản trị metadata cực sâu.',
+    strength: 'AI Governance, Watson, độ chín muồi cho enterprise',
     color: '#1F70C1',
   },
   {
     vendor: 'AWS',
     logo: '🟠',
     solution: 'Amazon DataZone',
-    philosophy: 'Su linh hoat: Ket noi moi dich vu AWS khong can copy.',
-    strength: 'Phu hop khi da dung nhieu dich vu AWS',
+    philosophy: 'Sự linh hoạt: Kết nối mọi dịch vụ AWS không cần copy.',
+    strength: 'Phù hợp khi đã dùng nhiều dịch vụ AWS',
     color: '#FF9900',
   },
   {
     vendor: 'SAP',
     logo: '🟦',
     solution: 'SAP Datasphere',
-    philosophy: 'Ngu canh kinh doanh: Giu nguyen y nghia du lieu ke toan/ERP.',
-    strength: 'Tot nhat khi cong ty dang dung SAP ERP',
+    philosophy: 'Ngữ cảnh kinh doanh: Giữ nguyên ý nghĩa dữ liệu kế toán/ERP.',
+    strength: 'Tốt nhất khi công ty đang dùng SAP ERP',
     color: '#0FAAFF',
   },
 ]
@@ -69,7 +69,7 @@ export function Slide21VendorsTable() {
               marginBottom: 10,
             }}
           >
-            Tren thi truong
+            Trên thị trường
           </div>
           <h2
             style={{
@@ -80,7 +80,7 @@ export function Slide21VendorsTable() {
               letterSpacing: '-0.02em',
             }}
           >
-            Cac giai phap Data Fabric hang dau
+            Các giải pháp Data Fabric hàng đầu
           </h2>
         </motion.div>
 
@@ -94,7 +94,7 @@ export function Slide21VendorsTable() {
               padding: '8px 16px',
             }}
           >
-            {['Nha cung cap', 'Giai phap chinh', 'Triet ly', 'Diem manh'].map((h) => (
+            {['Nhà cung cấp', 'Giải pháp chính', 'Triết lý', 'Điểm mạnh'].map((h) => (
               <div
                 key={h}
                 style={{

--- a/slides/data-fabric-de-hieu/src/slides/22-diagram-ecosystem.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/22-diagram-ecosystem.tsx
@@ -50,7 +50,7 @@ export function Slide22DiagramEcosystem() {
             letterSpacing: '-0.02em',
           }}
         >
-          He sinh thai Data Fabric
+          Hệ sinh thái Data Fabric
         </h2>
       </motion.div>
 
@@ -69,7 +69,7 @@ export function Slide22DiagramEcosystem() {
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 12 }}>
           <motion.div variants={scaleIn}>
             <div style={{ fontSize: '0.65rem', fontWeight: 700, color: theme.colors.accentGreen, textTransform: 'uppercase', letterSpacing: '0.12em', marginBottom: 8 }}>
-              Tang ung dung
+              Tầng ứng dụng
             </div>
             <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
               {rings[0].items.map((item) => (
@@ -102,7 +102,7 @@ export function Slide22DiagramEcosystem() {
 
           <motion.div variants={scaleIn}>
             <div style={{ fontSize: '0.65rem', fontWeight: 700, color: theme.colors.accentAlt, textTransform: 'uppercase', letterSpacing: '0.12em', marginBottom: 8 }}>
-              Tang tieu thu du lieu
+              Tầng tiêu thụ dữ liệu
             </div>
             <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
               {rings[1].items.map((item) => (
@@ -164,7 +164,7 @@ export function Slide22DiagramEcosystem() {
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 12 }}>
           <motion.div variants={scaleIn}>
             <div style={{ fontSize: '0.65rem', fontWeight: 700, color: '#D97706', textTransform: 'uppercase', letterSpacing: '0.12em', marginBottom: 8 }}>
-              Nguon du lieu
+              Nguồn dữ liệu
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               {['SQL / NoSQL Databases', 'Cloud Storage (S3, Azure Blob)', 'SaaS Applications', 'Streaming / Kafka', 'Legacy Systems'].map((src) => (

--- a/slides/data-fabric-de-hieu/src/slides/23-section-roadmap.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/23-section-roadmap.tsx
@@ -77,8 +77,8 @@ export function Slide23SectionRoadmap() {
             letterSpacing: '-0.02em',
           }}
         >
-          Lo trinh{' '}
-          <span style={{ color: theme.colors.accent }}>trien khai (Roadmap)</span>
+          Lộ trình{' '}
+          <span style={{ color: theme.colors.accent }}>triển khai (Roadmap)</span>
         </motion.h2>
         <motion.div
           initial={{ scaleX: 0 }}

--- a/slides/data-fabric-de-hieu/src/slides/24-diagram-roadmap.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/24-diagram-roadmap.tsx
@@ -6,54 +6,54 @@ const phases = [
   {
     phase: 'Phase 1',
     title: 'Data Audit & Catalog',
-    duration: 'Thang 1-2',
+    duration: 'Tháng 1-2',
     tasks: [
-      'Kiem ke toan bo nguon du lieu hien co',
-      'Xac dinh cac silo du lieu quan trong',
-      'Danh gia chat luong va do tin cay',
-      'Chon cong cu Data Catalog phu hop',
+      'Kiểm kê toàn bộ nguồn dữ liệu hiện có',
+      'Xác định các silo dữ liệu quan trọng',
+      'Đánh giá chất lượng và độ tin cậy',
+      'Chọn công cụ Data Catalog phù hợp',
     ],
     color: '#DC2626',
-    status: 'Nen lam truoc',
+    status: 'Nên làm trước',
   },
   {
     phase: 'Phase 2',
     title: 'Foundation & Connectivity',
-    duration: 'Thang 3-4',
+    duration: 'Tháng 3-4',
     tasks: [
-      'Trien khai Data Fabric platform',
-      'Ket noi cac nguon du lieu chinh',
-      'Cau hinh basic metadata tagging',
-      'Thiet lap chinh sach truy cap co ban',
+      'Triển khai Data Fabric platform',
+      'Kết nối các nguồn dữ liệu chính',
+      'Cấu hình basic metadata tagging',
+      'Thiết lập chính sách truy cập cơ bản',
     ],
     color: '#D97706',
-    status: 'Nen tang',
+    status: 'Nền tảng',
   },
   {
     phase: 'Phase 3',
     title: 'Intelligence & Governance',
-    duration: 'Thang 5-8',
+    duration: 'Tháng 5-8',
     tasks: [
-      'Bat AI tu dong hoa metadata',
-      'Cau hinh Data Lineage day du',
-      'Trien khai Data Quality monitoring',
-      'Training user va data steward',
+      'Bật AI tự động hóa metadata',
+      'Cấu hình Data Lineage đầy đủ',
+      'Triển khai Data Quality monitoring',
+      'Training user và data steward',
     ],
     color: theme.colors.accent,
-    status: 'Mo rong',
+    status: 'Mở rộng',
   },
   {
     phase: 'Phase 4',
     title: 'Scale & Optimize',
-    duration: 'Thang 9+',
+    duration: 'Tháng 9+',
     tasks: [
-      'Mo rong ra toan to chuc',
-      'Tich hop voi AI/ML workloads',
-      'Tu dong hoa quy trinh Data Ops',
-      'Do luong va toi uu ROI',
+      'Mở rộng ra toàn tổ chức',
+      'Tích hợp với AI/ML workloads',
+      'Tự động hóa quy trình Data Ops',
+      'Đo lường và tối ưu ROI',
     ],
     color: theme.colors.accentGreen,
-    status: 'Tang truong',
+    status: 'Tăng trưởng',
   },
 ]
 
@@ -87,7 +87,7 @@ export function Slide24DiagramRoadmap() {
             letterSpacing: '-0.02em',
           }}
         >
-          Lo trinh trien khai Data Fabric
+          Lộ trình triển khai Data Fabric
         </h2>
       </motion.div>
 
@@ -231,8 +231,8 @@ export function Slide24DiagramRoadmap() {
           fontStyle: 'italic',
         }}
       >
-        Lo trinh co the dieu chinh tuy theo quy mo to chuc va he thong hien co.
-        Nen bat dau voi pilot project nho de chung minh gia tri truoc khi scale up.
+        Lộ trình có thể điều chỉnh tùy theo quy mô tổ chức và hệ thống hiện có.
+        Nên bắt đầu với pilot project nhỏ để chứng minh giá trị trước khi scale up.
       </motion.div>
     </div>
   )


### PR DESCRIPTION
Closes #34

STATUS: IMPLEMENTED

Jira issue: https://ignify-rd.atlassian.net/browse/RD-1113
Repository: https://github.com/ignify-rd/public-slides

Summary: Thêm dấu tiếng Việt vào slide data-fabric-de-hieu

## Plan

## Mục tiêu
Thêm đầy đủ dấu tiếng Việt vào tất cả chuỗi văn bản trong deck `data-fabric-de-hieu`.

## Branch làm việc
Checkout từ branch `rd-1108-copy-slide-deck-data-fabric-d-hi-u-v-o-public-sl` (nơi deck đang tồn tại).

## Các file cần sửa
Tất cả file trong `slides/data-fabric-de-hieu/src/slides/` — đặc biệt các file có chuỗi không dấu đã xác định:

- `03-diagram-silos.tsx` — `"Khong 'noi chuyen' duoc voi nhau"` → `"Không 'nói chuyện' được với nhau"`
- `05-challenges.tsx` — `"Du lieu nam rai rac..."`, `"Du lieu 'toi' (Dark Data)"`, v.v.
- `09-data-context.tsx` — `"Diem 'dat' nhat cua Data Fabric:"`
- `15-diagram-problems.tsx` — `"Con so 'doanh thu Q3' nay lay tu bao cao nao?"`
- `17-resolution-methods.tsx` — nhiều chuỗi mô tả dài
- `19-example-content.tsx` — nhiều chuỗi mô tả dài

Kiểm tra toàn bộ các file còn lại trong thư mục để không bỏ sót.

## Các bước thực hiện
1. Đọc lần lượt từng file `.tsx` trong `slides/data-fabric-de-hieu/src/slides/`.
2. Xác định tất cả chuỗi tiếng Việt không dấu (string literals và JSX text).
3. Thay thế bằng bản có dấu đúng chuẩn tiếng Việt.
4. Chạy `npm ci && npx tsc --noEmit && npx vite build` trong `slides/data-fabric-de-hieu/` để xác nhận build thành công.
5. Tạo PR từ branch hiện tại (hoặc branch mới) vào `main`.

## Tiêu chí hoàn thành
- Không còn chuỗi tiếng Việt nào thiếu dấu trong toàn bộ deck.
- Build CI (`tsc --noEmit` + `vite build`) pass không có lỗi.