### PR TITLE
fix: Sửa slide rd-1106-ai-orchestration [RD-1112]

### DIFF
--- a/slides/rd-1106-ai-orchestration/src/slides/SlideEvolution.tsx
+++ b/slides/rd-1106-ai-orchestration/src/slides/SlideEvolution.tsx
@@ -64,10 +64,10 @@ export function SlideEvolution({ highlightedStage }: SlideEvolutionProps) {
         Mỗi bước tiến mở ra khả năng mới - từ trả lời câu hỏi đơn giản đến điều phối hàng trăm tác nhân AI làm việc cùng nhau.
       </p>
       <div className="flex gap-3 flex-1 items-stretch">
-        {STAGE_CARDS.map((stage, i) => {
+        {STAGE_CARDS.flatMap((stage, i) => {
           const isHighlighted = hasHighlight && i === highlightedStage
           const isDimmed = hasHighlight && !isHighlighted
-          return (
+          const card = (
             <div
               key={stage.label}
               className={`flex-1 flex flex-col items-center justify-center rounded-2xl p-5 border-2 transition-all duration-200
@@ -88,6 +88,10 @@ export function SlideEvolution({ highlightedStage }: SlideEvolutionProps) {
               </p>
             </div>
           )
+          if (i < STAGE_CARDS.length - 1) {
+            return [card, <span key={`arrow-${i}`} className="text-2xl text-gray-400 self-center flex-none">→</span>]
+          }
+          return [card]
         })}
       </div>
     </SlideWrapper>

--- a/slides/rd-1106-ai-orchestration/src/slides/SlidesAIAgent.tsx
+++ b/slides/rd-1106-ai-orchestration/src/slides/SlidesAIAgent.tsx
@@ -2,9 +2,14 @@ import { SlideWrapper } from '../components/SlideWrapper'
 
 function SlideAIAgent01() {
   return (
-    <SlideWrapper>
-      <h2 className="text-3xl font-extrabold text-gray-900 mb-4">AI Agent</h2>
-      <div className="flex gap-8 flex-1 min-h-0">
+    <SlideWrapper className="relative overflow-hidden">
+      <img
+        src={`${import.meta.env.BASE_URL}assets/ai-agent.png`}
+        alt="AI Agent minh hoa"
+        className="absolute inset-0 w-full h-full object-cover opacity-15"
+      />
+      <div className="relative z-10 flex flex-col flex-1 min-h-0">
+        <h2 className="text-3xl font-extrabold text-gray-900 mb-4">AI Agent</h2>
         <div className="flex-1 flex flex-col gap-4">
           <p className="text-base text-gray-600 leading-relaxed">
             AI Agent tiến một bước xa hơn chatbot: thay vì chỉ trả lời, Agent có thể
@@ -31,13 +36,6 @@ function SlideAIAgent01() {
               </div>
             </div>
           </div>
-        </div>
-        <div className="flex-none w-64 flex items-center justify-center">
-          <img
-            src={`${import.meta.env.BASE_URL}assets/ai-agent.png`}
-            alt="AI Agent minh hoa"
-            className="max-w-full max-h-full object-contain rounded-xl shadow"
-          />
         </div>
       </div>
     </SlideWrapper>

--- a/slides/rd-1106-ai-orchestration/src/slides/SlidesChatbot.tsx
+++ b/slides/rd-1106-ai-orchestration/src/slides/SlidesChatbot.tsx
@@ -2,9 +2,14 @@ import { SlideWrapper } from '../components/SlideWrapper'
 
 function SlideChatbot01() {
   return (
-    <SlideWrapper>
-      <h2 className="text-3xl font-extrabold text-gray-900 mb-4">Chatbot</h2>
-      <div className="flex gap-8 flex-1 min-h-0">
+    <SlideWrapper className="relative overflow-hidden">
+      <img
+        src={`${import.meta.env.BASE_URL}assets/chatbot.png`}
+        alt="Chatbot minh hoa"
+        className="absolute inset-0 w-full h-full object-cover opacity-15"
+      />
+      <div className="relative z-10 flex flex-col flex-1 min-h-0">
+        <h2 className="text-3xl font-extrabold text-gray-900 mb-4">Chatbot</h2>
         <div className="flex-1 flex flex-col gap-4">
           <p className="text-base text-gray-600 leading-relaxed">
             Chatbot là hình thức AI đầu tiên được doanh nghiệp triển khai rộng rãi.
@@ -28,46 +33,9 @@ function SlideChatbot01() {
             <p className="text-sm text-amber-800">Không thể tự chủ hành động - chỉ phản hồi, không chủ động xử lý công việc phức tạp.</p>
           </div>
         </div>
-        <div className="flex-none w-64 flex items-center justify-center">
-          <img
-            src={`${import.meta.env.BASE_URL}assets/chatbot.png`}
-            alt="Chatbot minh hoa"
-            className="max-w-full max-h-full object-contain rounded-xl shadow"
-          />
-        </div>
       </div>
     </SlideWrapper>
   )
 }
 
-function SlideChatbot02() {
-  const examples = [
-    { company: 'Ngân hàng', useCase: 'Bot tư vấn sản phẩm, tra cứu số dư, mở tài khoản online' },
-    { company: 'Bán lẻ', useCase: 'Tư vấn sản phẩm, theo dõi đơn hàng, xử lý đổi/trả hàng' },
-    { company: 'Nhân sự', useCase: 'Onboarding nhân viên mới, giải đáp chính sách nội bộ' },
-  ]
-  return (
-    <SlideWrapper>
-      <h2 className="text-3xl font-extrabold text-gray-900 mb-6">
-        Chatbot trong doanh nghiệp - Ứng dụng phổ biến
-      </h2>
-      <div className="flex flex-col gap-4 flex-1">
-        {examples.map((e) => (
-          <div key={e.company} className="flex items-start gap-4 bg-white border border-gray-200 rounded-xl p-5 shadow-sm">
-            <div className="flex-none w-24 text-sm font-bold text-blue-700 bg-blue-50 rounded-lg px-2 py-1.5 text-center">
-              {e.company}
-            </div>
-            <p className="text-sm text-gray-700 leading-relaxed mt-0.5">{e.useCase}</p>
-          </div>
-        ))}
-        <div className="bg-gray-100 rounded-xl p-4 mt-2">
-          <p className="text-sm text-gray-700 font-medium">
-            Chatbot phù hợp nhất khi: quy trình có thể được định nghĩa trước, câu hỏi lặp lại nhiều, cần phản hồi nhanh.
-          </p>
-        </div>
-      </div>
-    </SlideWrapper>
-  )
-}
-
-export const slidesChatbot = [SlideChatbot01, SlideChatbot02]
+export const slidesChatbot = [SlideChatbot01]

--- a/slides/rd-1106-ai-orchestration/src/slides/SlidesOrchestration.tsx
+++ b/slides/rd-1106-ai-orchestration/src/slides/SlidesOrchestration.tsx
@@ -32,16 +32,17 @@ function SlideOrchestration01() {
 
 function SlideOrchestration02() {
   return (
-    <SlideWrapper>
-      <h2 className="text-3xl font-extrabold text-gray-900 mb-4">
-        AI Orchestration trong thực tế
-      </h2>
-      <div className="flex-1 flex items-center justify-center">
-        <img
-          src={`${import.meta.env.BASE_URL}assets/orchestration-showcase.png`}
-          alt="AI Orchestration showcase"
-          className="max-h-full max-w-full object-contain rounded-xl shadow"
-        />
+    <SlideWrapper className="relative overflow-hidden">
+      <img
+        src={`${import.meta.env.BASE_URL}assets/orchestration-showcase.png`}
+        alt="AI Orchestration showcase"
+        className="absolute inset-0 w-full h-full object-cover"
+      />
+      <div className="absolute inset-0 bg-gradient-to-b from-white via-transparent to-transparent" />
+      <div className="relative z-10 flex flex-col flex-1">
+        <h2 className="text-3xl font-extrabold text-gray-900 mb-4">
+          AI Orchestration trong thực tế
+        </h2>
       </div>
     </SlideWrapper>
   )

--- a/slides/rd-1106-ai-orchestration/src/slides/SlidesTransition.tsx
+++ b/slides/rd-1106-ai-orchestration/src/slides/SlidesTransition.tsx
@@ -40,7 +40,7 @@ export function SlideTransitionToAIAgent() {
     <TransitionSlide
       emoji="🤔"
       heading="Vậy... Chatbot được rồi."
-      highlight="Nhưng doanh nghiệp cần AI tự hành động."
+      highlight="Nhưng chúng ta cần AI tự hành động."
       subtitle="Chatbot giỏi trả lời - nhưng không tự làm việc. Khi bài toán phức tạp hơn, AI Agent ra đời."
     />
   )


### PR DESCRIPTION
Closes #33

STATUS: IMPLEMENTED

Jira issue: https://ignify-rd.atlassian.net/browse/RD-1112
Repository: https://github.com/ignify-rd/public-slides

Summary: Sửa slide rd-1106-ai-orchestration

## Plan

## Các thay đổi cần thực hiện

### 1. Thêm mũi tên giữa các giai đoạn — `SlideEvolution.tsx`
- Trong vòng lặp render `STAGE_CARDS`, sau mỗi card (trừ card cuối) thêm một phần tử mũi tên `→` (ví dụ `<span className="text-2xl text-gray-400 self-center flex-none">→</span>`) giữa các card.

### 2. Xóa slide "Chatbot trong doanh nghiệp - Ứng dụng phổ biến" — `SlidesChatbot.tsx`
- Xóa toàn bộ component `SlideChatbot02`.
- Cập nhật export: `export const slidesChatbot = [SlideChatbot01]`.

### 3. Đổi wording slide chuyển tiếp sang AI Agent — `SlidesTransition.tsx`
- Tại `SlideTransitionToAIAgent`, thay `highlight="Nhưng doanh nghiệp cần AI tự hành động."` bằng wording không đề cập doanh nghiệp, ví dụ: `highlight="Nhưng chúng ta cần AI tự hành động."`.
- Cập nhật `subtitle` tương ứng nếu cần để giữ nhất quán (hiện tại subtitle cũng dùng "Chatbot giỏi trả lời - nhưng không tự làm việc. Khi bài toán phức tạp hơn, AI Agent ra đời." — không cần sửa subtitle này).

### 4. Chuyển ảnh minh họa thành background — các slide có ảnh inline
Các ảnh hiện đang dùng như content element với viền/shadow:
- `chatbot.png` trong `SlideChatbot01` (dòng 32–37): bỏ `rounded-xl shadow`, chuyển thành background tuyệt đối (`absolute inset-0 object-cover opacity-XX`) với overlay, tương tự cách `super-colleague.gif` đã được xử lý trong `SlideReveal03`.
- `ai-agent.png` trong `SlidesAIAgent.tsx`: kiểm tra và xử lý tương tự.
- `orchestration-showcase.png` trong `SlidesOrchestration.tsx`: kiểm tra và xử lý tương tự.

> **Lưu ý:** `super-colleague.gif` đã là background (absolute inset-0 w-full h-full object-cover) — không cần thay đổi.

## Các file cần chỉnh sửa
- `slides/rd-1106-ai-orchestration/src/slides/SlideEvolution.tsx`
- `slides/rd-1106-ai-orchestration/src/slides/SlidesChatbot.tsx`
- `slides/rd-1106-ai-orchestration/src/slides/SlidesTransition.tsx`
- `slides/rd-1106-ai-orchestration/src/slides/SlidesAIAgent.tsx`
- `slides/rd-1106-ai-orchestration/src/slides/SlidesOrchestration.tsx`

## Kiểm tra
- `npm ci && npx tsc --noEmit && npx vite build` từ thư mục `slides/rd-1106-ai-orchestration/` phải pass.
- Xem lại từng slide bị ảnh hưởng để đảm bảo layout không bị vỡ sau khi ảnh chuyển sang background.