### PR TITLE
fix: Sửa nội dung và layout deck rd-1106-ai-orchestration [RD-1115]

### DIFF
--- a/slides/rd-1106-ai-orchestration/src/slides/SlideEvolution.tsx
+++ b/slides/rd-1106-ai-orchestration/src/slides/SlideEvolution.tsx
@@ -58,10 +58,10 @@ export function SlideEvolution({ highlightedStage }: SlideEvolutionProps) {
         </span>
       </div>
       <h2 className="text-3xl font-extrabold text-gray-900 mb-2">
-        AI trong doanh nghiệp phát triển qua từng giai đoạn
+        Câu chuyện dẫn dắt: Hành trình AI qua từng giai đoạn
       </h2>
       <p className="text-base text-gray-500 mb-6 max-w-2xl leading-relaxed">
-        Mỗi bước tiến mở ra khả năng mới - từ trả lời câu hỏi đơn giản đến điều phối hàng trăm tác nhân AI làm việc cùng nhau.
+        Mỗi giai đoạn là một chương trong câu chuyện - từ hình thái đầu tiên của LLM đến điều phối hàng trăm tác nhân AI làm việc cùng nhau.
       </p>
       <div className="flex gap-3 flex-1 items-stretch">
         {STAGE_CARDS.flatMap((stage, i) => {

--- a/slides/rd-1106-ai-orchestration/src/slides/SlidesAIAgent.tsx
+++ b/slides/rd-1106-ai-orchestration/src/slides/SlidesAIAgent.tsx
@@ -54,9 +54,9 @@ function SlideAIAgent02() {
       <h2 className="text-3xl font-extrabold text-gray-900 mb-6">
         AI Agent - Năng lực thực thi
       </h2>
-      <div className="grid grid-cols-2 gap-4 flex-1">
+      <div className="grid grid-cols-2 grid-rows-2 gap-4 flex-1">
         {capabilities.map((c) => (
-          <div key={c.title} className="bg-white border border-gray-200 rounded-xl p-5 shadow-sm">
+          <div key={c.title} className="bg-white border border-gray-200 rounded-xl p-5 shadow-sm flex flex-col justify-center">
             <div className="flex items-center gap-2 mb-2">
               <span className="text-2xl">{c.icon}</span>
               <p className="font-bold text-gray-900 text-sm">{c.title}</p>

--- a/slides/rd-1106-ai-orchestration/src/slides/SlidesAIMindset.tsx
+++ b/slides/rd-1106-ai-orchestration/src/slides/SlidesAIMindset.tsx
@@ -8,60 +8,6 @@ function SectionBadge({ text }: { text: string }) {
   )
 }
 
-function SlideAIMindset01() {
-  const stats = [
-    { value: '78%', label: 'doanh nghiệp Fortune 500 đang triển khai AI' },
-    { value: '3x', label: 'tăng năng suất trung bình với AI tools đúng cách' },
-    { value: '60%', label: 'nhân viên muốn được đào tạo về AI' },
-  ]
-  return (
-    <SlideWrapper>
-      <SectionBadge text="Tư duy AI" />
-      <h2 className="text-3xl font-extrabold text-gray-900 mb-8">
-        AI trong doanh nghiệp - Thực trạng hiện nay
-      </h2>
-      <div className="grid grid-cols-3 gap-6 flex-1">
-        {stats.map((s) => (
-          <div key={s.value} className="bg-white border border-gray-200 rounded-xl p-6 flex flex-col gap-2 shadow-sm">
-            <span className="text-5xl font-extrabold text-blue-600">{s.value}</span>
-            <span className="text-sm text-gray-600 leading-snug">{s.label}</span>
-          </div>
-        ))}
-      </div>
-      <p className="mt-6 text-sm text-gray-400 italic">
-        Nguồn: McKinsey Global Survey on AI 2024, Microsoft WorkLab
-      </p>
-    </SlideWrapper>
-  )
-}
-
-function SlideAIMindset02() {
-  const points = [
-    { icon: '🧭', title: 'AI là công cụ chiến lược', body: 'Không chỉ là tự động hóa - AI tạo ra lợi thế cạnh tranh dài hạn cho toàn tổ chức.' },
-    { icon: '🤝', title: 'Con người + AI = sức mạnh nhân đôi', body: 'Lãnh đạo cần xây dựng văn hóa "AI-augmented" thay vì "AI-replaced".' },
-    { icon: '📈', title: 'Đầu tư vào năng lực AI', body: 'Đào tạo đội ngũ, thiết lập quy trình, và đo lường hiệu quả ứng dụng AI.' },
-  ]
-  return (
-    <SlideWrapper>
-      <SectionBadge text="Tư duy lãnh đạo" />
-      <h2 className="text-3xl font-extrabold text-gray-900 mb-8">
-        Mindset của lãnh đạo trong kỷ nguyên AI
-      </h2>
-      <div className="flex flex-col gap-4 flex-1">
-        {points.map((p) => (
-          <div key={p.title} className="flex gap-4 bg-white border border-gray-200 rounded-xl p-5 shadow-sm">
-            <span className="text-2xl flex-none mt-0.5">{p.icon}</span>
-            <div>
-              <p className="font-bold text-gray-900 mb-1">{p.title}</p>
-              <p className="text-sm text-gray-600 leading-relaxed">{p.body}</p>
-            </div>
-          </div>
-        ))}
-      </div>
-    </SlideWrapper>
-  )
-}
-
 function SlideAIMindset03() {
   const misconceptions = [
     {
@@ -104,4 +50,4 @@ function SlideAIMindset03() {
   )
 }
 
-export const slidesAIMindset = [SlideAIMindset01, SlideAIMindset02, SlideAIMindset03]
+export const slidesAIMindset = [SlideAIMindset03]

--- a/slides/rd-1106-ai-orchestration/src/slides/SlidesChatbot.tsx
+++ b/slides/rd-1106-ai-orchestration/src/slides/SlidesChatbot.tsx
@@ -9,11 +9,11 @@ function SlideChatbot01() {
         className="absolute inset-0 w-full h-full object-cover opacity-15"
       />
       <div className="relative z-10 flex flex-col flex-1 min-h-0">
-        <h2 className="text-3xl font-extrabold text-gray-900 mb-4">Chatbot</h2>
+        <h2 className="text-3xl font-extrabold text-gray-900 mb-4">Hình thái đầu tiên của LLM - AI</h2>
         <div className="flex-1 flex flex-col gap-4">
           <p className="text-base text-gray-600 leading-relaxed">
-            Chatbot là hình thức AI đầu tiên được doanh nghiệp triển khai rộng rãi.
-            Nó hoạt động theo mô hình hỏi - đáp: người dùng gửi câu hỏi, AI phản hồi ngay lập tức.
+            Hình thái đầu tiên của LLM trong doanh nghiệp là chatbot: AI hoạt động theo mô hình hỏi - đáp,
+            người dùng gửi câu hỏi, AI phản hồi ngay lập tức.
           </p>
           <div className="grid grid-cols-2 gap-3">
             {[

--- a/slides/rd-1106-ai-orchestration/src/slides/SlidesOrchestration.tsx
+++ b/slides/rd-1106-ai-orchestration/src/slides/SlidesOrchestration.tsx
@@ -48,42 +48,6 @@ function SlideOrchestration02() {
   )
 }
 
-function SlideOrchestration03() {
-  const frameworks = [
-    { name: 'LangGraph', desc: 'Framework open-source cho multi-agent workflows với state management mạnh mẽ' },
-    { name: 'AutoGen (Microsoft)', desc: 'Multi-agent framework cho phép các AI tự thảo luận và phân công nhiệm vụ' },
-    { name: 'CrewAI', desc: 'Xây dựng "crew" các AI chuyên biệt với vai trò và nhiệm vụ được định nghĩa rõ' },
-    { name: 'Claude Orchestration', desc: 'Anthropic cung cấp native multi-agent support với tính an toàn cao' },
-  ]
-  return (
-    <SlideWrapper>
-      <div className="mb-3">
-        <span className="inline-block text-xs font-bold tracking-widest text-blue-600 uppercase bg-blue-50 px-3 py-1 rounded">
-          Framework & Công nghệ
-        </span>
-      </div>
-      <h2 className="text-3xl font-extrabold text-gray-900 mb-6">
-        Các framework AI Orchestration phổ biến
-      </h2>
-      <div className="flex flex-col gap-3 flex-1">
-        {frameworks.map((f) => (
-          <div key={f.name} className="flex items-start gap-4 bg-white border border-gray-200 rounded-xl p-4 shadow-sm">
-            <div className="flex-none w-36 font-bold text-blue-700 text-sm bg-blue-50 rounded-lg px-3 py-2 text-center">
-              {f.name}
-            </div>
-            <p className="text-sm text-gray-700 leading-relaxed mt-1">{f.desc}</p>
-          </div>
-        ))}
-        <div className="bg-gray-100 rounded-xl p-3 mt-1">
-          <p className="text-sm text-gray-600">
-            Lựa chọn framework phụ thuộc vào: độ phức tạp của workflow, yêu cầu bảo mật, và hệ thống hiện có của doanh nghiệp.
-          </p>
-        </div>
-      </div>
-    </SlideWrapper>
-  )
-}
-
 function SlideOrchestration04() {
   const layers = [
     {
@@ -138,6 +102,5 @@ function SlideOrchestration04() {
 export const slidesOrchestration = [
   SlideOrchestration01,
   SlideOrchestration02,
-  SlideOrchestration03,
   SlideOrchestration04,
 ]

--- a/slides/rd-1106-ai-orchestration/src/slides/SlidesPersonalAssistant.tsx
+++ b/slides/rd-1106-ai-orchestration/src/slides/SlidesPersonalAssistant.tsx
@@ -29,9 +29,6 @@ function SlidePersonalAssistant01() {
           <p className="text-xs text-blue-800 leading-relaxed">
             "Sáng mai có meeting với client - tôi cần tóm tắt 3 email gần nhất, chuẩn bị agenda, và soạn email nhắc lại cho team."
           </p>
-          <p className="text-xs text-blue-600 font-medium mt-auto">
-            - Personal AI Assistant thực hiện tất cả trong 30 giây
-          </p>
         </div>
       </div>
     </SlideWrapper>
@@ -97,7 +94,7 @@ function SlidePersonalAssistant03() {
       <h2 className="text-3xl font-extrabold text-gray-900 mb-6">
         Bảo mật khi dùng Personal AI Assistant
       </h2>
-      <div className="flex flex-col gap-4 flex-1">
+      <div className="flex flex-col gap-4 flex-1 justify-between">
         {risks.map((r) => (
           <div key={r.risk} className="bg-white border border-gray-200 rounded-xl p-5 shadow-sm">
             <div className="flex items-start gap-3">
@@ -121,7 +118,7 @@ function SlidePersonalAssistant04() {
   return (
     <SlideWrapper>
       <h2 className="text-3xl font-extrabold text-gray-900 mb-6">Meta & AI</h2>
-      <div className="flex-1 flex items-center justify-center">
+      <div className="flex-1 min-h-0 flex items-center justify-center overflow-hidden">
         <img
           src={`${import.meta.env.BASE_URL}assets/meta-case.png`}
           alt="Meta AI case study"


### PR DESCRIPTION
Closes #40

STATUS: IMPLEMENTED

Jira issue: https://ignify-rd.atlassian.net/browse/RD-1115
Repository: https://github.com/ignify-rd/public-slides

Summary: Sửa slide rd-1106-ai-orchestration

## Plan

## Mục tiêu
Chỉnh sửa nội dung và layout cho deck `slides/rd-1106-ai-orchestration/` trên branch `rd-1106-ai-orchestration`.

---

## Các thay đổi cần thực hiện

### 1. Xóa slide "AI trong doanh nghiệp - Thực trạng hiện nay" (Slide 2)
- **File:** `src/slides/SlidesAIMindset.tsx`
- Xóa component `SlideAIMindset01` khỏi file.
- Xóa entry tương ứng trong mảng slides ở `App.tsx` (hoặc file đăng ký slides).

### 2. Xóa slide "Mindset của lãnh đạo trong kỷ nguyên AI" (Slide 3)
- **File:** `src/slides/SlidesAIMindset.tsx`
- Xóa component `SlideAIMindset02` khỏi file.
- Xóa entry tương ứng trong mảng slides.

### 3. Đổi tên "Chatbot / bước đầu tiên" → "Hình thái đầu tiên của LLM - AI" (Slide 6)
- **File:** `src/slides/SlidesChatbot.tsx` — component `SlideChatbot01`
- Đổi tiêu đề Stage 1 từ "Chatbot" / "Vậy … hành trình bắt đầu từ đâu. Từ chatbot bước đầu tiên" thành **"Hình thái đầu tiên của LLM - AI"**.
- Điều chỉnh framing của "Lộ trình tiến hóa" (`SlideEvolution`, `src/slides/SlideEvolution.tsx`): nhấn mạnh đây là **câu chuyện dẫn dắt người xem**, không phải lộ trình triển khai thực tế — chỉ sửa trong nội dung text/heading của slide, không thêm chú thích hay annotation.

### 4. Sửa layout slide 9/30 — "AI Agent - Năng lực thực thi"
- **File:** `src/slides/SlidesAIAgent.tsx` — component `SlideAIAgent02`
- GIF/ảnh đang quá to: giới hạn kích thước, đặt vào một góc (ví dụ: góc phải hoặc trái, `max-w-xs` hoặc tương đương).
- 4 ô nội dung đang dồn lên trên cùng, phần giữa trống: điều chỉnh layout để nội dung dàn đều cả trang (dùng `justify-between`, `items-center`, hoặc chia grid cân đối).

### 5. Sửa layout slide 12/30 — "Bảo mật khi dùng Personal AI Assistant"
- **File:** `src/slides/SlidesPersonalAssistant.tsx` — component `SlidePersonalAssistant03`
- Cùng vấn đề layout như slide 9: nội dung dồn lên trên, khoảng giữa trống — áp dụng fix tương tự.

### 6. Xóa "Personal AI Assistant thực hiện tất cả trong 30 giây" (Slide 13)
- **File:** `src/slides/SlidesPersonalAssistant.tsx` — component `SlidePersonalAssistant04`
- Xóa section/block "Personal AI Assistant thực hiện tất cả trong 30 giây" khỏi slide (hoặc xóa toàn bộ component nếu đây là nội dung duy nhất).
- Xóa entry tương ứng khỏi mảng slides nếu component bị xóa hoàn toàn.

### 7. Sửa ảnh slide "Meta & AI" (Slide 13, cùng file)
- **File:** `src/slides/SlidesPersonalAssistant.tsx` — component `SlidePersonalAssistant04`
- Ảnh đang bị to, bị cắt: thêm `object-contain`, giới hạn `max-h` / `max-w` để toàn bộ ảnh hiển thị đầy đủ trong khung hình.

### 8. Xóa slide "Các framework AI Orchestration" (Slide 16)
- **File:** `src/slides/SlidesOrchestration.tsx` — component `SlideOrchestration03`
- Xóa component `SlideOrchestration03` khỏi file.
- Xóa entry tương ứng khỏi mảng slides.

---

## Verification
- Chạy `npx tsc --noEmit` và `npx vite build` — cả hai phải pass.
- Kiểm tra số slide sau khi xóa: tổng số slide giảm tương ứng (xóa 4 slides: AIMindset01, AIMindset02, frameworks, và possibly PersonalAssistant04).
- Kiểm tra layout slide 9 và 12 trên preview: nội dung dàn đều, không còn khoảng trống giữa trang.
- Kiểm tra ảnh slide Meta & AI: ảnh hiển thị đầy đủ trong khung.