### PR TITLE
fix: xóa title khỏi các slide diagram full-screen trong data-fabric-de-hieu [RD-1119]

### DIFF
--- a/slides/data-fabric-de-hieu/src/slides/13b-image-part3a.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/13b-image-part3a.tsx
@@ -38,20 +38,6 @@ export function SlidePart3ImageA() {
         }}
       />
 
-      {/* Title */}
-      <div
-        style={{
-          position: 'relative',
-          zIndex: 1,
-          padding: '32px 60px 16px',
-          color: theme.colors.text,
-          fontSize: theme.sizes.subheading,
-          fontWeight: 700,
-        }}
-      >
-        Kiến trúc Data Fabric
-      </div>
-
       {/* Image */}
       <div
         style={{
@@ -61,7 +47,7 @@ export function SlidePart3ImageA() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '0 60px 32px',
+          padding: '4px',
         }}
       >
         <img

--- a/slides/data-fabric-de-hieu/src/slides/13c-image-part3b.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/13c-image-part3b.tsx
@@ -38,20 +38,6 @@ export function SlidePart3ImageB() {
         }}
       />
 
-      {/* Title */}
-      <div
-        style={{
-          position: 'relative',
-          zIndex: 1,
-          padding: '32px 60px 16px',
-          color: theme.colors.text,
-          fontSize: theme.sizes.subheading,
-          fontWeight: 700,
-        }}
-      >
-        Data Fabric vs Data Mesh
-      </div>
-
       {/* Image */}
       <div
         style={{
@@ -61,7 +47,7 @@ export function SlidePart3ImageB() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '0 60px 32px',
+          padding: '4px',
         }}
       >
         <img

--- a/slides/data-fabric-de-hieu/src/slides/14b-image-permission.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/14b-image-permission.tsx
@@ -38,20 +38,6 @@ export function SlidePart4Permission() {
         }}
       />
 
-      {/* Title */}
-      <div
-        style={{
-          position: 'relative',
-          zIndex: 1,
-          padding: '32px 60px 16px',
-          color: theme.colors.text,
-          fontSize: theme.sizes.subheading,
-          fontWeight: 700,
-        }}
-      >
-        Phân quyền
-      </div>
-
       {/* Image */}
       <div
         style={{
@@ -61,7 +47,7 @@ export function SlidePart4Permission() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '0 60px 32px',
+          padding: '4px',
         }}
       >
         <img

--- a/slides/data-fabric-de-hieu/src/slides/14c-image-conflict.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/14c-image-conflict.tsx
@@ -38,20 +38,6 @@ export function SlidePart4Conflict() {
         }}
       />
 
-      {/* Title */}
-      <div
-        style={{
-          position: 'relative',
-          zIndex: 1,
-          padding: '32px 60px 16px',
-          color: theme.colors.text,
-          fontSize: theme.sizes.subheading,
-          fontWeight: 700,
-        }}
-      >
-        Xung đột dữ liệu
-      </div>
-
       {/* Image */}
       <div
         style={{
@@ -61,7 +47,7 @@ export function SlidePart4Conflict() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '0 60px 32px',
+          padding: '4px',
         }}
       >
         <img


### PR DESCRIPTION
Closes #48

STATUS: IMPLEMENTED

Jira issue: https://ignify-rd.atlassian.net/browse/RD-1119
Repository: https://github.com/ignify-rd/public-slides

Summary: Sửa ảnh không hiển thị hết data-fabric-de-hieu

## Plan

## Problem

Slides `13b-image-part3a`, `13c-image-part3b`, `14b-image-permission`, `14c-image-conflict` mỗi slide có một title block với `padding: '32px 60px 16px'` chiếm khoảng 80px chiều cao. Image container dùng `flex: 1` + `maxHeight: '100%'`, nhưng `100%` resolve theo chiều cao của flex container (không phải toàn bộ slide 720px), khiến phần dưới của ảnh bị cắt.

## Implementation

Branch off từ `rd-1117-s-a-diagram-images-kh-ng-hi-n-th-y-trong-data-fa` (nơi đã có các slide image này).

Với mỗi file sau trong `slides/data-fabric-de-hieu/src/slides/`:
- `13b-image-part3a.tsx`
- `13c-image-part3b.tsx`
- `14b-image-permission.tsx`
- `14c-image-conflict.tsx`

Thực hiện 2 thay đổi:
1. **Xóa toàn bộ title `<div>`** (khối chứa text "Kiến trúc Data Fabric", "Data Fabric vs Data Mesh", "Phân quyền", v.v.)
2. **Cập nhật padding của image container**: đổi `padding: '0 60px 32px'` thành `padding: '4px'` (hoặc `0`) để ảnh chiếm toàn bộ chiều cao còn lại.

Sau khi xóa title, container `flex: 1` sẽ có toàn bộ 720px, và `maxHeight: '100%'` sẽ giới hạn ảnh đúng với chiều cao slide.

## Verification

```bash
cd slides/data-fabric-de-hieu
npm ci
npx tsc --noEmit
npx vite build
```

Kiểm tra các slide 13b, 13c, 14b, 14c trong trình duyệt để xác nhận ảnh hiển thị đầy đủ không bị cắt.