### PR TITLE
fix: Xóa tiêu đề Bước 1/2/3 và sửa ảnh diagram bị tràn [RD-1120]

### DIFF
--- a/slides/data-fabric-de-hieu/src/slides/07b-step1.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/07b-step1.tsx
@@ -38,20 +38,6 @@ export function SlideStep1() {
         }}
       />
 
-      {/* Title */}
-      <div
-        style={{
-          position: 'relative',
-          zIndex: 1,
-          padding: '32px 60px 16px',
-          color: theme.colors.text,
-          fontSize: theme.sizes.subheading,
-          fontWeight: 700,
-        }}
-      >
-        Bước 1
-      </div>
-
       {/* Image */}
       <div
         style={{
@@ -61,7 +47,7 @@ export function SlideStep1() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '0 60px 32px',
+          padding: '4px',
         }}
       >
         <img

--- a/slides/data-fabric-de-hieu/src/slides/07b-step1.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/07b-step1.tsx
@@ -25,37 +25,26 @@ export function SlideStep1() {
         }}
       />
 
-      {/* Top accent bar */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          height: 4,
-          background: `linear-gradient(90deg, ${theme.colors.accent} 0%, ${theme.colors.accentAlt} 100%)`,
-          zIndex: 2,
-        }}
-      />
-
       {/* Image */}
       <div
         style={{
           position: 'relative',
           zIndex: 1,
           flex: 1,
+          minWidth: 0,
+          minHeight: 0,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '4px',
         }}
       >
         <img
           src="/public-slides/data-fabric-de-hieu/images/step1.png"
           alt="Bước 1"
           style={{
-            maxWidth: '100%',
-            maxHeight: '100%',
+            width: '100%',
+            height: '100%',
+            display: 'block',
             objectFit: 'contain',
           }}
         />

--- a/slides/data-fabric-de-hieu/src/slides/07c-step2.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/07c-step2.tsx
@@ -38,20 +38,6 @@ export function SlideStep2() {
         }}
       />
 
-      {/* Title */}
-      <div
-        style={{
-          position: 'relative',
-          zIndex: 1,
-          padding: '32px 60px 16px',
-          color: theme.colors.text,
-          fontSize: theme.sizes.subheading,
-          fontWeight: 700,
-        }}
-      >
-        Bước 2
-      </div>
-
       {/* Image */}
       <div
         style={{
@@ -61,7 +47,7 @@ export function SlideStep2() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '0 60px 32px',
+          padding: '4px',
         }}
       >
         <img

--- a/slides/data-fabric-de-hieu/src/slides/07c-step2.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/07c-step2.tsx
@@ -25,37 +25,26 @@ export function SlideStep2() {
         }}
       />
 
-      {/* Top accent bar */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          height: 4,
-          background: `linear-gradient(90deg, ${theme.colors.accent} 0%, ${theme.colors.accentAlt} 100%)`,
-          zIndex: 2,
-        }}
-      />
-
       {/* Image */}
       <div
         style={{
           position: 'relative',
           zIndex: 1,
           flex: 1,
+          minWidth: 0,
+          minHeight: 0,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '4px',
         }}
       >
         <img
           src="/public-slides/data-fabric-de-hieu/images/step2.png"
           alt="Bước 2"
           style={{
-            maxWidth: '100%',
-            maxHeight: '100%',
+            width: '100%',
+            height: '100%',
+            display: 'block',
             objectFit: 'contain',
           }}
         />

--- a/slides/data-fabric-de-hieu/src/slides/07d-step3.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/07d-step3.tsx
@@ -25,37 +25,26 @@ export function SlideStep3() {
         }}
       />
 
-      {/* Top accent bar */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          height: 4,
-          background: `linear-gradient(90deg, ${theme.colors.accent} 0%, ${theme.colors.accentAlt} 100%)`,
-          zIndex: 2,
-        }}
-      />
-
       {/* Image */}
       <div
         style={{
           position: 'relative',
           zIndex: 1,
           flex: 1,
+          minWidth: 0,
+          minHeight: 0,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '4px',
         }}
       >
         <img
           src="/public-slides/data-fabric-de-hieu/images/step3.png"
           alt="Bước 3"
           style={{
-            maxWidth: '100%',
-            maxHeight: '100%',
+            width: '100%',
+            height: '100%',
+            display: 'block',
             objectFit: 'contain',
           }}
         />

--- a/slides/data-fabric-de-hieu/src/slides/07d-step3.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/07d-step3.tsx
@@ -38,20 +38,6 @@ export function SlideStep3() {
         }}
       />
 
-      {/* Title */}
-      <div
-        style={{
-          position: 'relative',
-          zIndex: 1,
-          padding: '32px 60px 16px',
-          color: theme.colors.text,
-          fontSize: theme.sizes.subheading,
-          fontWeight: 700,
-        }}
-      >
-        Bước 3
-      </div>
-
       {/* Image */}
       <div
         style={{
@@ -61,7 +47,7 @@ export function SlideStep3() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '0 60px 32px',
+          padding: '4px',
         }}
       >
         <img

--- a/slides/data-fabric-de-hieu/src/slides/08-diagram-fabric.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/08-diagram-fabric.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion'
 import { theme } from '../lib/theme'
-import { container, scaleIn, fadeInUp } from '../lib/animations'
+import { container, scaleIn } from '../lib/animations'
 
 const sources = ['Excel', 'Cloud DB', 'SQL Server', 'SaaS', 'API']
 const consumers = ['Power BI', 'AI/ML', 'Analytics', 'Apps']
@@ -22,29 +22,6 @@ export function Slide08DiagramFabric() {
         padding: '36px 60px',
       }}
     >
-      <motion.div
-        variants={fadeInUp}
-        initial="hidden"
-        animate="show"
-        style={{
-          textAlign: 'center',
-          marginBottom: 40,
-        }}
-      >
-        <h2
-          style={{
-            fontSize: 'clamp(1.5rem, 3vw, 2.4rem)',
-            fontWeight: 800,
-            color: theme.colors.text,
-            letterSpacing: '-0.02em',
-          }}
-        >
-          Data Fabric:{' '}
-          <span style={{ color: theme.colors.accent }}>Smart Layer</span>{' '}
-          kết nối mọi nguồn
-        </h2>
-      </motion.div>
-
       <motion.div
         variants={container}
         initial="hidden"

--- a/slides/data-fabric-de-hieu/src/slides/12-diagram-architecture.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/12-diagram-architecture.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion'
 import { theme } from '../lib/theme'
-import { container, scaleIn, fadeInUp } from '../lib/animations'
+import { container, scaleIn } from '../lib/animations'
 
 const departments = [
   { name: 'Phong Sales', color: '#7C3AED', data: ['SQL Server', 'base_pay'] },
@@ -26,24 +26,6 @@ export function Slide12DiagramArchitecture() {
         padding: '32px 60px',
       }}
     >
-      <motion.div
-        variants={fadeInUp}
-        initial="hidden"
-        animate="show"
-        style={{ textAlign: 'center', marginBottom: 32 }}
-      >
-        <h2
-          style={{
-            fontSize: 'clamp(1.4rem, 2.8vw, 2.2rem)',
-            fontWeight: 800,
-            color: theme.colors.text,
-            letterSpacing: '-0.02em',
-          }}
-        >
-          Công ty sử dụng Data Fabric - Trước và Sau
-        </h2>
-      </motion.div>
-
       <motion.div
         variants={container}
         initial="hidden"

--- a/slides/data-fabric-de-hieu/src/slides/13-diagram-components.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/13-diagram-components.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion'
 import { theme } from '../lib/theme'
-import { container, scaleIn, fadeInUp } from '../lib/animations'
+import { container, scaleIn } from '../lib/animations'
 
 const components = [
   {
@@ -57,24 +57,6 @@ export function Slide13DiagramComponents() {
         padding: '32px 60px',
       }}
     >
-      <motion.div
-        variants={fadeInUp}
-        initial="hidden"
-        animate="show"
-        style={{ textAlign: 'center', marginBottom: 32 }}
-      >
-        <h2
-          style={{
-            fontSize: 'clamp(1.4rem, 2.8vw, 2.2rem)',
-            fontWeight: 800,
-            color: theme.colors.text,
-            letterSpacing: '-0.02em',
-          }}
-        >
-          Các thành phần cốt lõi của Data Fabric
-        </h2>
-      </motion.div>
-
       <motion.div
         variants={container}
         initial="hidden"

--- a/slides/data-fabric-de-hieu/src/slides/13b-image-part3a.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/13b-image-part3a.tsx
@@ -25,37 +25,26 @@ export function SlidePart3ImageA() {
         }}
       />
 
-      {/* Top accent bar */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          height: 4,
-          background: `linear-gradient(90deg, ${theme.colors.accent} 0%, ${theme.colors.accentAlt} 100%)`,
-          zIndex: 2,
-        }}
-      />
-
       {/* Image */}
       <div
         style={{
           position: 'relative',
           zIndex: 1,
           flex: 1,
+          minWidth: 0,
+          minHeight: 0,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '4px',
         }}
       >
         <img
           src="/public-slides/data-fabric-de-hieu/images/part3a.png"
           alt="Kiến trúc Data Fabric"
           style={{
-            maxWidth: '100%',
-            maxHeight: '100%',
+            width: '100%',
+            height: '100%',
+            display: 'block',
             objectFit: 'contain',
           }}
         />

--- a/slides/data-fabric-de-hieu/src/slides/13c-image-part3b.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/13c-image-part3b.tsx
@@ -25,37 +25,26 @@ export function SlidePart3ImageB() {
         }}
       />
 
-      {/* Top accent bar */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          height: 4,
-          background: `linear-gradient(90deg, ${theme.colors.accent} 0%, ${theme.colors.accentAlt} 100%)`,
-          zIndex: 2,
-        }}
-      />
-
       {/* Image */}
       <div
         style={{
           position: 'relative',
           zIndex: 1,
           flex: 1,
+          minWidth: 0,
+          minHeight: 0,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '4px',
         }}
       >
         <img
           src="/public-slides/data-fabric-de-hieu/images/data-fabric-vs-mesh.png"
           alt="Data Fabric vs Data Mesh"
           style={{
-            maxWidth: '100%',
-            maxHeight: '100%',
+            width: '100%',
+            height: '100%',
+            display: 'block',
             objectFit: 'contain',
           }}
         />

--- a/slides/data-fabric-de-hieu/src/slides/14b-image-permission.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/14b-image-permission.tsx
@@ -25,37 +25,26 @@ export function SlidePart4Permission() {
         }}
       />
 
-      {/* Top accent bar */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          height: 4,
-          background: `linear-gradient(90deg, ${theme.colors.accent} 0%, ${theme.colors.accentAlt} 100%)`,
-          zIndex: 2,
-        }}
-      />
-
       {/* Image */}
       <div
         style={{
           position: 'relative',
           zIndex: 1,
           flex: 1,
+          minWidth: 0,
+          minHeight: 0,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '4px',
         }}
       >
         <img
           src="/public-slides/data-fabric-de-hieu/images/permission.png"
           alt="Phân quyền"
           style={{
-            maxWidth: '100%',
-            maxHeight: '100%',
+            width: '100%',
+            height: '100%',
+            display: 'block',
             objectFit: 'contain',
           }}
         />

--- a/slides/data-fabric-de-hieu/src/slides/14c-image-conflict.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/14c-image-conflict.tsx
@@ -25,37 +25,26 @@ export function SlidePart4Conflict() {
         }}
       />
 
-      {/* Top accent bar */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          height: 4,
-          background: `linear-gradient(90deg, ${theme.colors.accent} 0%, ${theme.colors.accentAlt} 100%)`,
-          zIndex: 2,
-        }}
-      />
-
       {/* Image */}
       <div
         style={{
           position: 'relative',
           zIndex: 1,
           flex: 1,
+          minWidth: 0,
+          minHeight: 0,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: '4px',
         }}
       >
         <img
           src="/public-slides/data-fabric-de-hieu/images/conflict.png"
           alt="Xung đột dữ liệu"
           style={{
-            maxWidth: '100%',
-            maxHeight: '100%',
+            width: '100%',
+            height: '100%',
+            display: 'block',
             objectFit: 'contain',
           }}
         />

--- a/slides/data-fabric-de-hieu/src/slides/22-diagram-ecosystem.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/22-diagram-ecosystem.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion'
 import { theme } from '../lib/theme'
-import { container, scaleIn, fadeInUp } from '../lib/animations'
+import { container, scaleIn } from '../lib/animations'
 
 const rings = [
   {
@@ -36,24 +36,6 @@ export function Slide22DiagramEcosystem() {
         padding: '32px 60px',
       }}
     >
-      <motion.div
-        variants={fadeInUp}
-        initial="hidden"
-        animate="show"
-        style={{ textAlign: 'center', marginBottom: 32 }}
-      >
-        <h2
-          style={{
-            fontSize: 'clamp(1.4rem, 2.8vw, 2.2rem)',
-            fontWeight: 800,
-            color: theme.colors.text,
-            letterSpacing: '-0.02em',
-          }}
-        >
-          Hệ sinh thái Data Fabric
-        </h2>
-      </motion.div>
-
       <motion.div
         variants={container}
         initial="hidden"

--- a/slides/data-fabric-de-hieu/src/slides/24-diagram-roadmap.tsx
+++ b/slides/data-fabric-de-hieu/src/slides/24-diagram-roadmap.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion'
 import { theme } from '../lib/theme'
-import { container, scaleIn, fadeInUp } from '../lib/animations'
+import { container, scaleIn } from '../lib/animations'
 
 const phases = [
   {
@@ -73,24 +73,6 @@ export function Slide24DiagramRoadmap() {
         padding: '28px 50px',
       }}
     >
-      <motion.div
-        variants={fadeInUp}
-        initial="hidden"
-        animate="show"
-        style={{ textAlign: 'center', marginBottom: 24 }}
-      >
-        <h2
-          style={{
-            fontSize: 'clamp(1.4rem, 2.8vw, 2.2rem)',
-            fontWeight: 800,
-            color: theme.colors.text,
-            letterSpacing: '-0.02em',
-          }}
-        >
-          Lộ trình triển khai Data Fabric
-        </h2>
-      </motion.div>
-
       {/* Timeline line */}
       <div
         style={{


### PR DESCRIPTION
Closes #50

STATUS: IMPLEMENTED

Jira issue: https://ignify-rd.atlassian.net/browse/RD-1120
Repository: https://github.com/ignify-rd/public-slides

Summary: Sửa slide data-fabric

## Plan

## Mục tiêu

Sửa 2 vấn đề trên slide deck `data-fabric-de-hieu`:
1. Xóa các tiêu đề "Bước 1", "Bước 2", "Bước 3" — vì diagram đã có sẵn label trong ảnh.
2. Sửa ảnh diagram full-slide bị clip ở phần dưới, dùng Playwright để xác nhận trước khi hoàn tất.

---

## Bước 1 — Xóa tiêu đề "Bước 1/2/3"

Trong `07b-step1.tsx`, `07c-step2.tsx`, `07d-step3.tsx`:
- Xóa hoàn toàn `<div>` chứa text "Bước 1" / "Bước 2" / "Bước 3".
- Giữ nguyên phần ảnh — chỉ đổi `padding` của image container từ `'0 60px 32px'` thành `'4px'` để ảnh tận dụng toàn bộ chiều cao còn lại (theo epic pattern đã biết).

## Bước 2 — Sửa ảnh diagram full-slide bị tràn

Các slide có ảnh full-slide cần kiểm tra và sửa (nếu có title div chiếm chỗ):

| File | Ảnh |
|------|-----|
| `08-diagram-fabric.tsx` | diagram-fabric |
| `12-diagram-architecture.tsx` | diagram-architecture |
| `13-diagram-components.tsx` | diagram-components |
| `13b-image-part3a.tsx` | part3a.png |
| `13c-image-part3b.tsx` | part3b.png |
| `14b-image-permission.tsx` | permission.png |
| `14c-image-conflict.tsx` | conflict.png |
| `22-diagram-ecosystem.tsx` | diagram-ecosystem |
| `24-diagram-roadmap.tsx` | diagram-roadmap |

Pattern sửa (từ epic memory): xóa title `<div>` khỏi slide đó và set `padding: '4px'` cho image container.

## Bước 3 — Xác nhận bằng Playwright

Sau khi sửa, dùng Playwright MCP để mở từng slide full-slide diagram trong browser (dev server hoặc built output), chụp screenshot và xác nhận ảnh hiển thị đầy đủ, không bị clip ở phần dưới. Lặp lại sửa → kiểm tra cho đến khi tất cả slide hiển thị đúng.

## Bước 4 — Build & TypeScript check

```bash
cd slides/data-fabric-de-hieu
npm ci
npx tsc --noEmit
npx vite build
```

Cả hai lệnh phải pass trước khi tạo PR.