### PR TITLE
feat: Make a page listing all slides [RD-1122]

### DIFF
--- a/.github/workflows/build-slides.yml
+++ b/.github/workflows/build-slides.yml
@@ -32,6 +32,9 @@ jobs:
             cp -r "slides/$name/dist" "docs/$name"
           done
 
+      - name: Generate index page
+        run: node scripts/generate-index.js
+
       - name: Commit built output
         run: |
           git config user.name  "github-actions[bot]"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ignify RD - Slide Decks</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      min-height: 100vh;
+      padding: 0 0 48px;
+    }
+
+    header {
+      background: #ffffff;
+      border-bottom: 1px solid #e2e8f0;
+      padding: 20px 32px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    header h1 {
+      font-size: 1.25rem;
+      font-weight: 700;
+      color: #0f172a;
+      letter-spacing: -0.01em;
+    }
+
+    header .badge {
+      font-size: 0.75rem;
+      font-weight: 600;
+      background: #ede9fe;
+      color: #6d28d9;
+      border-radius: 9999px;
+      padding: 2px 10px;
+    }
+
+    main {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 40px 24px 0;
+    }
+
+    .section-title {
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: #64748b;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin-bottom: 20px;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 20px;
+    }
+
+    @media (max-width: 1024px) {
+      .grid { grid-template-columns: repeat(3, 1fr); }
+    }
+    @media (max-width: 700px) {
+      .grid { grid-template-columns: repeat(2, 1fr); gap: 14px; }
+    }
+    @media (max-width: 400px) {
+      .grid { grid-template-columns: 1fr; }
+    }
+
+    .card {
+      display: flex;
+      flex-direction: column;
+      background: #ffffff;
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      overflow: hidden;
+      text-decoration: none;
+      color: inherit;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+    }
+
+    .card:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 12px 28px rgba(0,0,0,0.12);
+      border-color: #c7d2fe;
+    }
+
+    .thumb {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 16px;
+    }
+
+    .thumb-text {
+      font-size: 0.6875rem;
+      font-weight: 700;
+      color: rgba(255,255,255,0.85);
+      text-align: center;
+      word-break: break-word;
+      letter-spacing: 0.02em;
+      line-height: 1.5;
+      text-shadow: 0 1px 3px rgba(0,0,0,0.3);
+    }
+
+    .card-body {
+      padding: 12px 14px 14px;
+    }
+
+    .card-title {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #0f172a;
+      line-height: 1.4;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Ignify RD Slides</h1>
+    <span class="badge">9 decks</span>
+  </header>
+  <main>
+    <p class="section-title">All Slide Decks</p>
+    <div class="grid">
+      
+    <a class="card" href="/public-slides/ai-era-human-role/" aria-label="Ai Era Human Role">
+      <div class="thumb" style="background: linear-gradient(135deg, #4F46E5 0%, #7C3AED 100%);">
+        <span class="thumb-text">ai-era-human-role</span>
+      </div>
+      <div class="card-body">
+        <p class="card-title">Ai Era Human Role</p>
+      </div>
+    </a>
+
+    <a class="card" href="/public-slides/data-fabric-de-hieu/" aria-label="Data Fabric De Hieu">
+      <div class="thumb" style="background: linear-gradient(135deg, #10B981 0%, #059669 100%);">
+        <span class="thumb-text">data-fabric-de-hieu</span>
+      </div>
+      <div class="card-body">
+        <p class="card-title">Data Fabric De Hieu</p>
+      </div>
+    </a>
+
+    <a class="card" href="/public-slides/employee-performance/" aria-label="Employee Performance">
+      <div class="thumb" style="background: linear-gradient(135deg, #F59E0B 0%, #D97706 100%);">
+        <span class="thumb-text">employee-performance</span>
+      </div>
+      <div class="card-body">
+        <p class="card-title">Employee Performance</p>
+      </div>
+    </a>
+
+    <a class="card" href="/public-slides/giao-tiep-hieu-qua-trong-team/" aria-label="Giao Tiep Hieu Qua Trong Team">
+      <div class="thumb" style="background: linear-gradient(135deg, #10B981 0%, #059669 100%);">
+        <span class="thumb-text">giao-tiep-hieu-qua-trong-team</span>
+      </div>
+      <div class="card-body">
+        <p class="card-title">Giao Tiep Hieu Qua Trong Team</p>
+      </div>
+    </a>
+
+    <a class="card" href="/public-slides/how-to-communicate-efficiently/" aria-label="How To Communicate Efficiently">
+      <div class="thumb" style="background: linear-gradient(135deg, #F97316 0%, #EA580C 100%);">
+        <span class="thumb-text">how-to-communicate-efficiently</span>
+      </div>
+      <div class="card-body">
+        <p class="card-title">How To Communicate Efficiently</p>
+      </div>
+    </a>
+
+    <a class="card" href="/public-slides/huong-dan-git/" aria-label="Huong Dan Git">
+      <div class="thumb" style="background: linear-gradient(135deg, #10B981 0%, #059669 100%);">
+        <span class="thumb-text">huong-dan-git</span>
+      </div>
+      <div class="card-body">
+        <p class="card-title">Huong Dan Git</p>
+      </div>
+    </a>
+
+    <a class="card" href="/public-slides/rd-1000-gstack-summary/" aria-label="Rd 1000 Gstack Summary">
+      <div class="thumb" style="background: linear-gradient(135deg, #0EA5E9 0%, #2563EB 100%);">
+        <span class="thumb-text">rd-1000-gstack-summary</span>
+      </div>
+      <div class="card-body">
+        <p class="card-title">Rd 1000 Gstack Summary</p>
+      </div>
+    </a>
+
+    <a class="card" href="/public-slides/rd-1102-claude-design/" aria-label="Rd 1102 Claude Design">
+      <div class="thumb" style="background: linear-gradient(135deg, #8B5CF6 0%, #6D28D9 100%);">
+        <span class="thumb-text">rd-1102-claude-design</span>
+      </div>
+      <div class="card-body">
+        <p class="card-title">Rd 1102 Claude Design</p>
+      </div>
+    </a>
+
+    <a class="card" href="/public-slides/rd-1106-ai-orchestration/" aria-label="Rd 1106 Ai Orchestration">
+      <div class="thumb" style="background: linear-gradient(135deg, #14B8A6 0%, #0D9488 100%);">
+        <span class="thumb-text">rd-1106-ai-orchestration</span>
+      </div>
+      <div class="card-body">
+        <p class="card-title">Rd 1106 Ai Orchestration</p>
+      </div>
+    </a>
+    </div>
+  </main>
+</body>
+</html>

--- a/scripts/generate-index.js
+++ b/scripts/generate-index.js
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+// Generate docs/index.html listing all slide decks as a card grid.
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO = path.resolve(__dirname, '..');
+const SLIDES_DIR = path.join(REPO, 'slides');
+const OUT_FILE = path.join(REPO, 'docs', 'index.html');
+
+function toTitle(slug) {
+  return slug
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// Stable color palette for thumbnail backgrounds (light theme)
+const COLORS = [
+  ['#4F46E5', '#7C3AED'], // indigo -> violet
+  ['#0EA5E9', '#2563EB'], // sky -> blue
+  ['#10B981', '#059669'], // emerald -> green
+  ['#F59E0B', '#D97706'], // amber -> orange
+  ['#EF4444', '#DC2626'], // red
+  ['#8B5CF6', '#6D28D9'], // violet -> purple
+  ['#14B8A6', '#0D9488'], // teal
+  ['#F97316', '#EA580C'], // orange
+  ['#EC4899', '#DB2777'], // pink
+  ['#6366F1', '#4338CA'], // indigo
+];
+
+function colorFor(slug) {
+  let hash = 0;
+  for (let i = 0; i < slug.length; i++) {
+    hash = (hash * 31 + slug.charCodeAt(i)) & 0xffffffff;
+  }
+  return COLORS[Math.abs(hash) % COLORS.length];
+}
+
+function buildCard(slug) {
+  const title = toTitle(slug);
+  const [c1, c2] = colorFor(slug);
+  const href = `/public-slides/${slug}/`;
+  return `
+    <a class="card" href="${href}" aria-label="${title}">
+      <div class="thumb" style="background: linear-gradient(135deg, ${c1} 0%, ${c2} 100%);">
+        <span class="thumb-text">${slug}</span>
+      </div>
+      <div class="card-body">
+        <p class="card-title">${title}</p>
+      </div>
+    </a>`;
+}
+
+function generate() {
+  const slugs = fs
+    .readdirSync(SLIDES_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+
+  const cards = slugs.map(buildCard).join('\n');
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ignify RD - Slide Decks</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: #f8fafc;
+      color: #1e293b;
+      min-height: 100vh;
+      padding: 0 0 48px;
+    }
+
+    header {
+      background: #ffffff;
+      border-bottom: 1px solid #e2e8f0;
+      padding: 20px 32px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    header h1 {
+      font-size: 1.25rem;
+      font-weight: 700;
+      color: #0f172a;
+      letter-spacing: -0.01em;
+    }
+
+    header .badge {
+      font-size: 0.75rem;
+      font-weight: 600;
+      background: #ede9fe;
+      color: #6d28d9;
+      border-radius: 9999px;
+      padding: 2px 10px;
+    }
+
+    main {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 40px 24px 0;
+    }
+
+    .section-title {
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: #64748b;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin-bottom: 20px;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 20px;
+    }
+
+    @media (max-width: 1024px) {
+      .grid { grid-template-columns: repeat(3, 1fr); }
+    }
+    @media (max-width: 700px) {
+      .grid { grid-template-columns: repeat(2, 1fr); gap: 14px; }
+    }
+    @media (max-width: 400px) {
+      .grid { grid-template-columns: 1fr; }
+    }
+
+    .card {
+      display: flex;
+      flex-direction: column;
+      background: #ffffff;
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      overflow: hidden;
+      text-decoration: none;
+      color: inherit;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+    }
+
+    .card:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 12px 28px rgba(0,0,0,0.12);
+      border-color: #c7d2fe;
+    }
+
+    .thumb {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 16px;
+    }
+
+    .thumb-text {
+      font-size: 0.6875rem;
+      font-weight: 700;
+      color: rgba(255,255,255,0.85);
+      text-align: center;
+      word-break: break-word;
+      letter-spacing: 0.02em;
+      line-height: 1.5;
+      text-shadow: 0 1px 3px rgba(0,0,0,0.3);
+    }
+
+    .card-body {
+      padding: 12px 14px 14px;
+    }
+
+    .card-title {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #0f172a;
+      line-height: 1.4;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Ignify RD Slides</h1>
+    <span class="badge">${slugs.length} decks</span>
+  </header>
+  <main>
+    <p class="section-title">All Slide Decks</p>
+    <div class="grid">
+      ${cards}
+    </div>
+  </main>
+</body>
+</html>
+`;
+
+  fs.mkdirSync(path.dirname(OUT_FILE), { recursive: true });
+  fs.writeFileSync(OUT_FILE, html, 'utf8');
+  console.log(`Generated ${OUT_FILE} with ${slugs.length} decks.`);
+}
+
+generate();


### PR DESCRIPTION
Closes #54

STATUS: IMPLEMENTED

Jira issue: https://ignify-rd.atlassian.net/browse/RD-1122
Repository: https://github.com/ignify-rd/public-slides

Summary: Make a page listing all slides

## Plan

## Goal

Create an index page at `https://ignify-rd.github.io/public-slides` (i.e., `docs/index.html`) that lists all slide decks in a YouTube-style card grid with thumbnail and title.

## Approach

Use a Node.js script (`scripts/generate-index.js`) that scans `slides/*/` to discover all decks, then writes a self-contained `docs/index.html` with embedded CSS. CI runs this script after all decks are built.

Thumbnails: **text-based** — each card's thumbnail area shows the deck's folder name (or a human-friendly title if derivable) as styled text on a colored background. This avoids Playwright/headless-browser complexity and always stays in sync.

## Steps

### 1. Create `scripts/generate-index.js`

- Read all subdirectory names from `slides/` (these are the deck slugs).
- For each slug, derive a display title: replace hyphens/underscores with spaces and title-case the words.
- Emit `docs/index.html` — a single self-contained HTML file with:
  - A responsive card grid (CSS Grid, 3–4 columns on desktop, 1–2 on mobile).
  - Each card: a thumbnail `<div>` (16:9 ratio, gradient background, centered slug text in a readable font), a title below, and an `<a>` wrapping the whole card linking to `/public-slides/<slug>/`.
  - Dark/light theme consistent with the rest of the site (light theme, per guardrails).
  - No external dependencies — all CSS inline or in a `<style>` block.

### 2. Update `.github/workflows/build-slides.yml`

After the "Build all decks" step and before "Commit built output", add:

```yaml
- name: Generate index page
  run: node scripts/generate-index.js
```

This ensures `docs/index.html` is regenerated on every push that touches `slides/**`.

### 3. Apply `ui-ux-pro-max` skill for visual polish

Run `ui-ux-pro-max` on the generated HTML/CSS in the script to ensure the card grid, typography, spacing, and hover states meet the design bar (shadow on hover, smooth transitions, clean font stack).

### 4. Local test

```bash
node scripts/generate-index.js
open docs/index.html   # verify cards render correctly
```

## File changes

| File | Action |
|---|---|
| `scripts/generate-index.js` | Create — index generator script |
| `.github/workflows/build-slides.yml` | Update — add generate-index step |
| `docs/index.html` | Generated artifact (committed by CI) |

## Out of scope

- Screenshot/real-slide thumbnails (too complex; text thumbnails satisfy the ticket's fallback condition).
- Pagination (deck count is small).