### PR TITLE
feat: Sắp xếp danh sách deck theo thứ tự mới nhất lên đầu trong generate-index.js [RD-1124]

### DIFF
--- a/scripts/generate-index.js
+++ b/scripts/generate-index.js
@@ -56,7 +56,7 @@ function generate() {
     .readdirSync(SLIDES_DIR, { withFileTypes: true })
     .filter((e) => e.isDirectory())
     .map((e) => e.name)
-    .sort();
+    .sort((a, b) => b.localeCompare(a));
 
   const cards = slugs.map(buildCard).join('\n');
 


### PR DESCRIPTION
Closes #57

STATUS: IMPLEMENTED

Jira issue: https://ignify-rd.atlassian.net/browse/RD-1124
Repository: https://github.com/ignify-rd/public-slides

Summary: Đổi lại thứ tự trong danh sách các deck: mới nhất lên đầu

## Plan

## Mục tiêu
Sửa `scripts/generate-index.js` để các deck trong `docs/index.html` được sắp xếp mới nhất lên đầu.

## Phân tích
Script hiện tại đọc các thư mục trong `slides/*/`, sinh card HTML cho mỗi deck, và ghi ra `docs/index.html`. Thứ tự hiện tại nhiều khả năng là thứ tự filesystem (alphabetical). Cần đảo ngược hoặc sắp xếp theo tiêu chí "mới nhất".

## Tiêu chí sắp xếp
Dùng **tên thư mục theo thứ tự alphabet ngược (Z→A / descending)**. Lý do:
- Tên deck thường có tiền tố ngày hoặc số thứ tự (ví dụ `rd-1106-…`, `rd-1050-…`).
- Không cần đọc mtime từ filesystem — tránh phụ thuộc vào thời gian clone/checkout của CI.
- Đơn giản, nhất quán, dễ kiểm tra.

## Các bước thực hiện

1. **Đọc file `scripts/generate-index.js`** để xác định đoạn code đọc danh sách thư mục deck.

2. **Thêm `.sort().reverse()`** (hoặc `.sort((a, b) => b.localeCompare(a))`) vào mảng tên deck sau khi `fs.readdirSync` / `glob` trả về danh sách.

   ```js
   // Trước
   const decks = fs.readdirSync(slidesDir).filter(...)
   
   // Sau
   const decks = fs.readdirSync(slidesDir)
     .filter(...)
     .sort((a, b) => b.localeCompare(a))  // mới nhất (tên lớn hơn) lên đầu
   ```

3. **Kiểm tra local**: chạy `node scripts/generate-index.js` và mở `docs/index.html` để xác nhận thứ tự đúng.

4. **Commit & push** lên nhánh, CI sẽ tự build lại và cập nhật `docs/index.html` trên main.

## File thay đổi
- `scripts/generate-index.js` — chỉ sửa logic sắp xếp, không thay đổi cấu trúc HTML/CSS card.